### PR TITLE
ENH: Make license more general

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022, Maxwell Grover
+Copyright (c) 2022, Open Radar Community Developers
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -2,6 +2,6 @@
 
 To use xradar in a project:
 
-    ```python
-    import xradar
-    ```
+```python
+import xradar
+```


### PR DESCRIPTION
Add "Open Radar Community Developers" to the license