### PR TITLE
Fix version on ReadTheDocs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,7 +37,9 @@ if on_rtd:
     commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
     print(f"Installing commit {commit}")
     url = "https://github.com/openradar/xradar.git"
-    subprocess.check_call(["python", "-m", "pip", "install", "--no-deps", f"git+{url}@{commit}"])
+    subprocess.check_call(
+        ["python", "-m", "pip", "install", "--no-deps", f"git+{url}@{commit}"]
+    )
 
 
 # -- General configuration ---------------------------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,11 +30,14 @@ sys.path.insert(0, os.path.abspath(".."))
 on_rtd = os.environ.get("READTHEDOCS") == "True"
 
 # processing on readthedocs
-# we need to specifically install the current xradar checkout to create version.py
+# we need to specifically install the current xradar commit to create version.py
 # this fixes the "999" version issue
 if on_rtd:
     # install xradar from checked out source
-    subprocess.check_call(["python", "-m", "pip", "install", "--no-deps", "../."])
+    commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
+    print(f"Installing commit {commit}")
+    url = "https://github.com/openradar/xradar.git"
+    subprocess.check_call(["python", "-m", "pip", "install", "--no-deps", f"git+{url}@{commit}"])
 
 
 # -- General configuration ---------------------------------------------

--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,11 @@
 
 ## Development Version
 
+* Add zenodo badges to README.md ({pull}`22`) by [@mgrover1](https://github.com/mgrover1)
+* Fix version on RTD ({pull}`23`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+
+## 0.6.0 (2022-09-19)
+
 * Improve installation and contribution guide, update README.md with more badges, add version and date of release to docs, update install process ({pull}`19`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * Add minimal documentation for CfRadial1 and ODIM_H5 importers ({pull}`20`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * Add accessors.py submodule, add accessors showcase  ({pull}`21`) by [@kmuehlbauer](https://github.com/kmuehlbauer)


### PR DESCRIPTION
For some reason the tagged versions (eg. 0.0.6) are not correctly installed. This version shows up as `0.0.7.dev0+g8f2753a.d20220920`.

This PR checks the commit on RTD and pip installs that commit directly from github. 

~This might break for PR builds, which we would need to detect and prepare for.~

This looks like it works nicely also for PR builds.