### PR TITLE
ENH: Generalize CfRadial1 reader

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.1.0
+    rev: v4.3.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -24,6 +24,7 @@ notebooks/Accessors
 :maxdepth: 2
 :caption: Examples
 
+notebooks/CfRadial1_Model_Transformation
 notebooks/CfRadial1
 notebooks/CfRadial1_full
 notebooks/ODIM_H5

--- a/examples/notebooks/Accessors.ipynb
+++ b/examples/notebooks/Accessors.ipynb
@@ -61,9 +61,7 @@
   {
    "cell_type": "markdown",
    "id": "0ed04dfa-eccc-4ca6-8864-25ce467518e2",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Open data"
    ]
@@ -292,7 +290,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/CfRadial1.ipynb
+++ b/examples/notebooks/CfRadial1.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# CfRadial1 - Simple"
    ]
@@ -55,12 +53,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7675b518-18e4-4ea6-b101-f1bccf603902",
+   "id": "0e0a7a18-3a4c-4940-96e0-6059f0b3da48",
    "metadata": {},
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\")\n",
-    "display(ds)"
+    "\n",
+    "with xr.set_options(display_expand_data_vars=True, display_max_rows=1000):\n",
+    "    display(ds)"
    ]
   },
   {
@@ -202,7 +202,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/CfRadial1_Model_Transformation.ipynb
+++ b/examples/notebooks/CfRadial1_Model_Transformation.ipynb
@@ -1,0 +1,463 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "59447ad6-ac47-494e-b696-4335b36b205b",
+   "metadata": {},
+   "source": [
+    "# CfRadial1 to CfRadial2 -  A data model transformation\n",
+    "\n",
+    "In this notebook we show how to transform the CfRadial1 Data model to a CfRadial2 representation. \n",
+    "\n",
+    "We use some internal functions to show how xradar is working inside.\n",
+    "\n",
+    "Within this notebook we reference to the [CfRadial2.1 draft](https://github.com/NCAR/CfRadial/tree/master/docs). As long as the FM301 WMO standard is not finalized we will rely on the drafts presented."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6f96b5d8-2b96-4fd7-b8ba-166c34a8dcd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import xradar as xd\n",
+    "import datatree as xt\n",
+    "from open_radar_data import DATASETS"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33d50be4-dfe5-4d99-a936-67a9a76bac94",
+   "metadata": {},
+   "source": [
+    "## Download\n",
+    "\n",
+    "Fetching CfRadial1 radar data file from [open-radar-data](https://github.com/openradar/open-radar-data) repository."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d3c6d408-5ab2-43c3-afd1-b3a703ef3b24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "filename = DATASETS.fetch(\"cfrad.20080604_002217_000_SPOL_v36_SUR.nc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b987dcfd-5105-4483-932e-71b8002e5f09",
+   "metadata": {},
+   "source": [
+    "## Open CfRadial1 file using xr.open_dataset\n",
+    "\n",
+    "Making use of the xarray `netcdf4` backend. We get back all data and metadata in one single CfRadial1 Dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e0a7a18-3a4c-4940-96e0-6059f0b3da48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(filename, engine=\"netcdf4\")\n",
+    "with xr.set_options(\n",
+    "    display_expand_data_vars=True, display_expand_attrs=True, display_max_rows=1000\n",
+    "):\n",
+    "    display(ds.load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b37bc43e",
+   "metadata": {},
+   "source": [
+    "## Extract CfRadial2 Groups and Subgroups\n",
+    "\n",
+    "Now as we have the CfRadial1 Dataset we can work towards extracting the CfRadial2 groups and subgroups. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e1d1b525",
+   "metadata": {},
+   "source": [
+    "### Extract CfRadial2 Root-Group\n",
+    "\n",
+    "The following sections present the details of the information in the top-level (root) group of the\n",
+    "data set.\n",
+    "\n",
+    "We use a convenience function to extract the CfRadial2 root group from the CfRadial1 Dataset. If we call with `optional=False` only mandatory data and metadata is imported."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e4b1557d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root = xd.io.backends.cfradial1._get_required_root_dataset(ds)\n",
+    "with xr.set_options(\n",
+    "    display_expand_data_vars=True, display_expand_attrs=True, display_max_rows=1000\n",
+    "):\n",
+    "    display(root.load())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fff2a34d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root = xd.io.backends.cfradial1._get_required_root_dataset(ds, optional=False)\n",
+    "with xr.set_options(\n",
+    "    display_expand_data_vars=True, display_expand_attrs=True, display_max_rows=1000\n",
+    "):\n",
+    "    display(root)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65cf9049",
+   "metadata": {},
+   "source": [
+    "### Extract Root-Group metadata groups\n",
+    "\n",
+    "The Cfradial2 Data Model has a notion of root group metadata groups. Those groups provide additional metadata covering other aspects of the radar system. \n",
+    "\n",
+    "#### The radar_parameters sub-group\n",
+    "\n",
+    "This group holds radar parameters specific to a radar instrument. It's implemented as dictionary where the value can be used to override the name."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b992ec33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(xd.model.radar_parameters_subgroup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fd5589ce",
+   "metadata": {},
+   "source": [
+    "Again we use a convenience function to extract the group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04af8243",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar_parameters = xd.io.backends.cfradial1._get_subgroup(\n",
+    "    ds, xd.model.radar_parameters_subgroup\n",
+    ")\n",
+    "display(radar_parameters.load())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0fa140a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar_parameters.to_netcdf(\"radar_parameters.nc\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c926508e",
+   "metadata": {},
+   "source": [
+    "#### The radar_calibration sub-group\n",
+    "\n",
+    "For a radar, a different calibration is required for each pulse width. Therefore the calibration\n",
+    "variables are arrays. If only one calibration is available it is squeezed by the reader."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8cb5f197",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(xd.model.radar_calibration_subgroup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6bcaa501",
+   "metadata": {},
+   "source": [
+    "Again we use a convenience function to extract the group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9f61ce7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar_calibration = xd.io.backends.cfradial1._get_radar_calibration(ds)\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(radar_calibration.load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "2ca0320a",
+   "metadata": {},
+   "source": [
+    "#### The georeference_correction sub-group\n",
+    "\n",
+    "The following additional variables are used to quantify errors in the georeference data for moving\n",
+    "platforms. These are constant for a volume."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9e76d49e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(xd.model.georeferencing_correction_subgroup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c7739019",
+   "metadata": {},
+   "source": [
+    "Again we use a convenience function to extract the group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a42c442f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "georeference_correction = xd.io.backends.cfradial1._get_subgroup(\n",
+    "    ds, xd.model.georeferencing_correction_subgroup\n",
+    ")\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(georeference_correction.load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "042da0a9",
+   "metadata": {},
+   "source": [
+    "### Sweep groups\n",
+    "\n",
+    "This section provides details of the information in each sweep group. The name of the sweep groups is found in the sweep_group_name array variable in the root group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70224a48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "root.sweep_group_name"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7f4f2c1c-5961-43f6-8c40-cbe796dd12dd",
+   "metadata": {},
+   "source": [
+    "Again we use a convenience function to extract the different sweep groups. Examining first sweep."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf93cd38-0f00-4dec-b7af-4e0ca6a111d1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweeps = xd.io.backends.cfradial1._get_sweep_groups(ds)\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(sweeps[\"sweep_0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38b326e1",
+   "metadata": {},
+   "source": [
+    "## Read as CfRadial2 data representation\n",
+    "\n",
+    "xradar provides two easy ways to retrieve the CfRadial1 data as CfRadial2 groups. \n",
+    "\n",
+    "### DataTree\n",
+    "\n",
+    "This is the most complete representation as a DataTree. All groups and subgroups are represented in a tree-like structure. Can be parameterized using kwargs. Easy write to netCDF4."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "efc02939",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtree = xd.io.open_cfradial1_datatree(filename)\n",
+    "with xr.set_options(display_expand_data_vars=True, display_expand_attrs=True):\n",
+    "    display(dtree)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "666b41bd",
+   "metadata": {},
+   "source": [
+    "Each DataTree-node itself represents another DataTree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "426b4256",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(dtree[\"radar_parameters\"].load())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "04083ab1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(dtree[\"sweep_7\"].load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55515cf9",
+   "metadata": {},
+   "source": [
+    "Write DataTree to netCDF4 file, reopen and compare with source."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65cd9185",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtree.to_netcdf(\"test_dtree.nc\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5921f261",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtree2 = xt.open_datatree(\"test_dtree.nc\")\n",
+    "with xr.set_options(display_expand_data_vars=True, display_expand_attrs=True):\n",
+    "    display(dtree2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf23b4ce",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for grp in dtree.groups:\n",
+    "    print(grp)\n",
+    "    xr.testing.assert_equal(dtree[grp].ds, dtree2[grp].ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "54aaa127",
+   "metadata": {},
+   "source": [
+    "### Datasets\n",
+    "\n",
+    "Using xarray.open_dataset and the cfradial1-backend we can easily load specific groups side-stepping the DataTree."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca7ba21f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(filename, group=\"sweep_1\", engine=\"cfradial1\", first_dim=\"auto\")\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(ds.load())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "003efee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(filename, group=\"radar_parameters\", engine=\"cfradial1\")\n",
+    "display(ds.load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "84b2975f",
+   "metadata": {},
+   "source": [
+    "## Conclusion\n",
+    "\n",
+    "CfRadial1 and CfRadial2 are based on the same principles with slightly different data representation. Nevertheless the conversion is relatively straighforward as has been shown here. \n",
+    "\n",
+    "As the implementation with the cfradial1 xarray backend on one hand and the DataTree on the other hand is very versatile users can pick the most usable approach for their workflows. "
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/CfRadial1_full.ipynb
+++ b/examples/notebooks/CfRadial1_full.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# CfRadial1 - Full"
    ]
@@ -176,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/Furuno.ipynb
+++ b/examples/notebooks/Furuno.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Furuno - Simple"
    ]

--- a/examples/notebooks/GAMIC.ipynb
+++ b/examples/notebooks/GAMIC.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# GAMIC - Simple"
    ]

--- a/examples/notebooks/GAMIC_full.ipynb
+++ b/examples/notebooks/GAMIC_full.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# GAMIC - Full"
    ]

--- a/examples/notebooks/Iris.ipynb
+++ b/examples/notebooks/Iris.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Iris - Simple"
    ]

--- a/examples/notebooks/Iris_full.ipynb
+++ b/examples/notebooks/Iris_full.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Iris - Full"
    ]

--- a/examples/notebooks/ODIM_H5.ipynb
+++ b/examples/notebooks/ODIM_H5.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# ODIM_H5 - Simple"
    ]
@@ -60,7 +58,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(filename, group=\"dataset1\", engine=\"odim\")\n",
-    "display(ds)"
+    "display(ds.load())"
    ]
   },
   {
@@ -186,7 +184,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/ODIM_H5_full.ipynb
+++ b/examples/notebooks/ODIM_H5_full.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# ODIM_H5 - Full"
    ]

--- a/examples/notebooks/Rainbow.ipynb
+++ b/examples/notebooks/Rainbow.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Rainbow - Simple"
    ]

--- a/examples/notebooks/Rainbow_full.ipynb
+++ b/examples/notebooks/Rainbow_full.ipynb
@@ -3,9 +3,7 @@
   {
    "cell_type": "markdown",
    "id": "59447ad6-ac47-494e-b696-4335b36b205b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "# Rainbow - Full"
    ]

--- a/examples/notebooks/plot-ppi.ipynb
+++ b/examples/notebooks/plot-ppi.ipynb
@@ -119,7 +119,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -56,7 +56,8 @@ def test_open_cfradial1_datatree(cfradial1_file):
         if grp == "/":
             continue
         ds = dtree[grp].ds
-        assert dict(ds.dims) == {"time": azimuths[i], "range": ranges[i]}
+        assert ds["azimuth"] == azimuths
+        assert ds["range"] == ranges
         assert set(ds.data_vars) & (
             sweep_dataset_vars | non_standard_sweep_dataset_vars
         ) == set(moments)
@@ -78,14 +79,14 @@ def test_open_cfradial1_datatree(cfradial1_file):
 def test_open_cfradial1_dataset(cfradial1_file):
     # open first sweep group
     ds = xr.open_dataset(cfradial1_file, group="sweep_0", engine="cfradial1")
-    assert dict(ds.dims) == {"time": 483, "range": 996}
+    assert list(ds.dims) == ["r_calib", "time", "range"]
     assert set(ds.data_vars) & (
         sweep_dataset_vars | non_standard_sweep_dataset_vars
     ) == {"DBZ", "VR"}
 
     # open last sweep group
     ds = xr.open_dataset(cfradial1_file, group="sweep_8", engine="cfradial1")
-    assert dict(ds.dims) == {"time": 483, "range": 996}
+    assert list(ds.dims) == ["r_calib", "time", "range"]
     assert set(ds.data_vars) & (
         sweep_dataset_vars | non_standard_sweep_dataset_vars
     ) == {"DBZ", "VR"}

--- a/xradar/georeference/transforms.py
+++ b/xradar/georeference/transforms.py
@@ -101,7 +101,7 @@ def get_x_y_z(ds, earth_radius=6371000, effective_radius_fraction=None):
         ds.azimuth,
         ds.elevation,
         earth_radius=earth_radius,
-        effective_radius_fraction=None,
+        effective_radius_fraction=effective_radius_fraction,
     )
 
     # Set the attributes for the dataset

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -38,14 +38,7 @@ from xarray.backends import NetCDF4DataStore
 from xarray.backends.common import BackendEntrypoint
 from xarray.backends.store import StoreBackendEntrypoint
 
-from ...model import (
-    non_standard_sweep_dataset_vars,
-    required_global_attrs,
-    required_root_vars,
-    required_sweep_metadata_vars,
-    sweep_coordinate_vars,
-    sweep_dataset_vars,
-)
+from ...model import required_global_attrs, required_root_vars
 from .common import _attach_sweep_groups, _maybe_decode
 
 
@@ -76,17 +69,8 @@ def _get_sweep_groups(root, sweep=None, first_dim="time"):
     ray_n_gates = root.get("ray_n_gates", False)
     ray_start_index = root.get("ray_start_index", False)
 
-    # strip variables and attributes
-    var = root.variables.keys()
-    keep_vars = (
-        sweep_coordinate_vars
-        | required_sweep_metadata_vars
-        | sweep_dataset_vars
-        | non_standard_sweep_dataset_vars
-    )
-    remove_vars = var ^ keep_vars
-    remove_vars &= var
-    data = root.drop_vars(remove_vars)
+    # strip attributes
+    data = root
     data.attrs = {}
     sweep_groups = []
     if isinstance(sweep, str):

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -32,29 +32,65 @@ __all__ = [
 
 __doc__ = __doc__.format("\n   ".join(__all__))
 
+import numpy as np
 from datatree import DataTree
 from xarray import open_dataset
 from xarray.backends import NetCDF4DataStore
 from xarray.backends.common import BackendEntrypoint
 from xarray.backends.store import StoreBackendEntrypoint
 
-from ...model import required_global_attrs, required_root_vars
+from ...model import (
+    georeferencing_correction_subgroup,
+    optional_root_attrs,
+    optional_root_vars,
+    radar_calibration_subgroup,
+    radar_parameters_subgroup,
+    required_global_attrs,
+    required_root_vars,
+    required_sweep_metadata_vars,
+    sweep_coordinate_vars,
+)
 from .common import _attach_sweep_groups, _maybe_decode
 
 
-def _get_required_root_dataset(ds):
+def _get_required_root_dataset(ds, optional=True):
     """Extract Root Dataset."""
-    # keep only mandatory variables
+    # keep only defined mandatory and defined optional variables per default
     var = ds.variables.keys()
-    remove_root = var ^ required_root_vars
+    remove_root = set(var) ^ set(required_root_vars)
+    if optional:
+        remove_root ^= set(optional_root_vars)
+    remove_root ^= {"sweep_number", "fixed_angle"}
     remove_root &= var
     root = ds.drop_vars(remove_root)
-    attrs = root.attrs.keys()
 
-    # keep only mandatory attributes
-    remove_attrs = (attrs ^ required_global_attrs) & attrs
+    # rename variables
+    # todo: find a more easy method not iterating over all variables
+    for k in root.data_vars:
+        rename = optional_root_vars.get(k, None)
+        if rename:
+            root = root.rename_vars({k: rename})
+
+    # keep only defined mandatory and defined optional attributes per default
+    attrs = root.attrs.keys()
+    remove_attrs = set(attrs) ^ set(required_global_attrs)
+    if optional:
+        remove_attrs ^= set(optional_root_attrs)
     for k in remove_attrs:
-        root.attrs.pop(k)
+        root.attrs.pop(k, None)
+
+    # handle sweep variables and dimension
+    root = root.rename_vars(
+        {"sweep_number": "sweep_group_name", "fixed_angle": "sweep_fixed_angle"}
+    )
+    root["sweep_group_name"].values = np.array(
+        [f"sweep_{i}" for i in root["sweep_group_name"].values]
+    )
+    # fix dtype in encoding
+    root.sweep_group_name.encoding["dtype"] = root.sweep_group_name.dtype
+    # remove cf standard name
+    root.sweep_group_name.attrs = []
+
     return root
 
 
@@ -63,16 +99,29 @@ def _get_sweep_groups(root, sweep=None, first_dim="time"):
 
     Ported from wradlib.
     """
-    # get hold of sweep start/stop indices
+    # get hold of sweep start/stop indices and remove variables
     start_idx = root.sweep_start_ray_index.values.astype(int)
     end_idx = root.sweep_end_ray_index.values.astype(int)
+    root = root.drop_vars(["sweep_start_ray_index", "sweep_end_ray_index"])
+
     ray_n_gates = root.get("ray_n_gates", False)
     ray_start_index = root.get("ray_start_index", False)
 
-    # strip attributes
-    data = root
+    # strip variables and attributes
+    anc_dims = list(set(root.dims) ^ {"time", "range", "sweep"})
+    root = root.drop_dims(anc_dims)
+
+    root = root.rename({"fixed_angle": "sweep_fixed_angle"})
+
+    keep_vars = sweep_coordinate_vars | required_sweep_metadata_vars
+    var = set(root.data_vars)
+    keep_vars2 = {k for k, v in root.data_vars.items() if "time" in v.dims}
+    remove_vars = var ^ (keep_vars | keep_vars2)
+    remove_vars &= var
+
+    data = root.drop_vars(remove_vars)
     data.attrs = {}
-    sweep_groups = []
+    sweep_groups = {}
     if isinstance(sweep, str):
         sweep = [sweep]
     elif isinstance(sweep, int):
@@ -125,38 +174,75 @@ def _get_sweep_groups(root, sweep=None, first_dim="time"):
         ds = ds.assign_coords({"azimuth": ds.azimuth})
         ds = ds.assign_coords({"elevation": ds.elevation})
 
-        # assign geo-coords
-        ds = ds.assign_coords(
-            {
-                "latitude": root.latitude,
-                "longitude": root.longitude,
-                "altitude": root.altitude,
-            }
-        )
-
-        sweep_groups.append(ds)
+        sweep_groups[sw] = ds
 
     return sweep_groups
 
 
-def _assign_data_radial(root, sweep="sweep_0", first_dim="time"):
-    """Assign from CfRadial1 data structure.
+def _get_cfradial2_group(ds, sweep="sweep_0", first_dim="time", optional=True):
+    """Assign CfRadial2 group from CfRadial1 data structure.
 
     Parameters
     ----------
-    root : xarray.Dataset
+    ds : xarray.Dataset
         Dataset of CfRadial1 file
-    sweep : int, optional
-        Sweep number to extract, default to first sweep. If None, all sweeps are
-        extracted into a list.
+    sweep : str, int, optional
+        Sweep/Group to extract, default to first sweep.
 
     Returns
     -------
-    sweeps : list
-        List of Sweep Datasets
+    sweep : xarray.Dataset
+        CfRadial2 group.
     """
-    sweeps = _get_sweep_groups(root, sweep, first_dim=first_dim)
-    return sweeps
+    if sweep in ["/", "root"]:
+        return _get_required_root_dataset(ds, optional=optional)
+    elif sweep in ["radar_calibration", "calib", "r_calib"]:
+        return _get_radar_calibration(ds)
+    elif sweep in ["radar_parameters"]:
+        return _get_subgroup(ds, radar_parameters_subgroup)
+    elif sweep in ["georeferencing_correction"]:
+        return _get_subgroup(ds, georeferencing_correction_subgroup)
+    elif "sweep" in sweep:
+        return list(_get_sweep_groups(ds, sweep, first_dim=first_dim).values())[0]
+    else:
+        return None
+
+
+def _get_subgroup(ds, subdict):
+    """Get CfRadial2 root metadata group.
+
+    Variables are fetched from the provided Dataset according to the subdict dictionary.
+    """
+    meta_vars = subdict
+    extract_vars = set(ds.data_vars) & set(meta_vars)
+    subgroup = ds[extract_vars]
+    for k in subgroup.data_vars:
+        rename = meta_vars[k]
+        if rename:
+            subgroup = subgroup.rename_vars({k: rename})
+    subgroup.attrs = {}
+    return subgroup
+
+
+def _get_radar_calibration(ds):
+    """Get radar calibration root metadata group."""
+    # radar_calibration is connected with calib-dimension
+    calib = [anc for anc in ds.dims if "calib" in anc]
+    if calib:
+        # extract group variables
+        subgroup = ds.drop_dims(list(set(ds.dims) ^ {calib[0]}))
+        drop = [k for k, v in subgroup.variables.items() if calib[0] not in v.dims]
+        subgroup = subgroup.drop_vars(drop).squeeze(calib[0])
+        calib_vars = {}
+        for name in subgroup.data_vars:
+            item = next(
+                filter(lambda x: x[0] in name, radar_calibration_subgroup.items())
+            )
+            item = item[1] if item[1] else item[0]
+            calib_vars[name] = item
+        subgroup = subgroup.rename_vars(calib_vars)
+        subgroup.attrs = {}
+        return subgroup
 
 
 def open_cfradial1_datatree(filename_or_obj, **kwargs):
@@ -182,20 +268,42 @@ def open_cfradial1_datatree(filename_or_obj, **kwargs):
     Returns
     -------
     dtree: DataTree
-        DataTree
+        DataTree with CfRadial2 groups.
     """
     # handle kwargs, extract first_dim
-    first_dim = kwargs.get("first_dim", None)
+    first_dim = kwargs.pop("first_dim", None)
+    optional = kwargs.pop("optional", True)
     sweep = kwargs.pop("sweep", None)
 
     # open root group, cfradial1 only has one group
-    ds = open_dataset(filename_or_obj, engine="cfradial1", **kwargs)
+    # open_cfradial1_datatree only opens the file once using netcdf4
+    # and retrieves the different groups from the loaded object
+    ds = open_dataset(filename_or_obj, engine="netcdf4", **kwargs)
+
     # create datatree root node with required data
-    dtree = DataTree(data=_get_required_root_dataset(ds), name="root")
+    root = _get_required_root_dataset(ds, optional=optional)
+    dtree = DataTree(data=root, name="root")
+
+    # additional root metadata groups
+    # radar_parameters
+    subgroup = _get_subgroup(ds, radar_parameters_subgroup)
+    DataTree(subgroup, name="radar_parameters", parent=dtree)
+
+    # radar_calibration (connected with calib-dimension)
+    calib = _get_radar_calibration(ds)
+    if calib:
+        DataTree(calib, name="radar_calibration", parent=dtree)
+
+    # georeferencing_correction
+    subgroup = _get_subgroup(ds, georeferencing_correction_subgroup)
+    DataTree(subgroup, name="georeferencing_correction", parent=dtree)
+
     # return datatree with attached sweep child nodes
-    return _attach_sweep_groups(
-        dtree, _get_sweep_groups(ds, sweep=sweep, first_dim=first_dim)
+    dtree = _attach_sweep_groups(
+        dtree, list(_get_sweep_groups(ds, sweep=sweep, first_dim=first_dim).values())
     )
+
+    return dtree
 
 
 class CfRadial1BackendEntrypoint(BackendEntrypoint):
@@ -227,6 +335,7 @@ class CfRadial1BackendEntrypoint(BackendEntrypoint):
         format=None,
         group="/",
         first_dim="time",
+        optional=True,
     ):
 
         store = NetCDF4DataStore.open(
@@ -248,11 +357,9 @@ class CfRadial1BackendEntrypoint(BackendEntrypoint):
             decode_timedelta=decode_timedelta,
         )
 
-        if group != "/":
-            ds = _assign_data_radial(ds, sweep=group, first_dim=first_dim)
-            if not ds:
-                raise ValueError(
-                    f"Group `{group}` missing from file `{filename_or_obj}`."
-                )
-            ds = ds[0]
+        ds = _get_cfradial2_group(
+            ds, sweep=group, first_dim=first_dim, optional=optional
+        )
+        if ds is None:
+            raise ValueError(f"Group `{group}` missing from file `{filename_or_obj}`.")
         return ds

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -231,7 +231,7 @@ class _GamicH5NetCDFMetadata:
             "sweep_number": Variable((), sweep_number),
             "prt_mode": Variable((), prt_mode),
             "follow_mode": Variable((), follow_mode),
-            "fixed_angle": Variable((), angle),
+            "sweep_fixed_angle": Variable((), angle),
             "longitude": Variable((), lon, get_longitude_attrs()),
             "latitude": Variable((), lat, get_latitude_attrs()),
             "altitude": Variable((), alt, get_altitude_attrs()),

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -3847,7 +3847,7 @@ class IrisStore(AbstractDataStore):
             "sweep_number": Variable((), sweep_number),
             "prt_mode": Variable((), prt_mode),
             "follow_mode": Variable((), follow_mode),
-            "fixed_angle": Variable((), fixed_angle),
+            "sweep_fixed_angle": Variable((), fixed_angle),
         }
 
         # a1gate

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -177,7 +177,7 @@ class _OdimH5NetCDFMetadata:
             "sweep_number": Variable((), sweep_number),
             "prt_mode": Variable((), prt_mode),
             "follow_mode": Variable((), follow_mode),
-            "fixed_angle": Variable((), angle),
+            "sweep_fixed_angle": Variable((), angle),
             "longitude": Variable((), lon, lon_attrs),
             "latitude": Variable((), lat, lat_attrs),
             "altitude": Variable((), alt, alt_attrs),
@@ -837,6 +837,7 @@ def open_odim_datatree(filename_or_obj, **kwargs):
         for swp in sweeps
     ]
 
+    # todo: apply CfRadial2 group structure below
     ds.insert(0, xr.open_dataset(filename_or_obj, group="/"))
 
     # create datatree root node with required data

--- a/xradar/io/backends/rainbow.py
+++ b/xradar/io/backends/rainbow.py
@@ -766,7 +766,7 @@ class RainbowStore(AbstractDataStore):
             "sweep_number": Variable((), sweep_number),
             "prt_mode": Variable((), prt_mode),
             "follow_mode": Variable((), follow_mode),
-            "fixed_angle": Variable((), float(var["posangle"])),
+            "sweep_fixed_angle": Variable((), float(var["posangle"])),
             "longitude": Variable((), lon, get_longitude_attrs()),
             "latitude": Variable((), lat, get_latitude_attrs()),
             "altitude": Variable((), alt, get_altitude_attrs()),

--- a/xradar/io/export.py
+++ b/xradar/io/export.py
@@ -215,7 +215,7 @@ def to_odim(dtree, filename):
         rscale = ds.range.values[1] / 1.0 - ds.range.values[0]
         rstart = (ds.range.values[0] - rscale / 2.0) / 1000.0
         a1gate = np.argsort(ds.sortby(dim0).time.values)[0]
-        fixed_angle = ds["fixed_angle"].values
+        fixed_angle = ds["sweep_fixed_angle"].values
         ds_where = {
             "elangle": fixed_angle,
             "nbins": ds.range.shape[0],

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -83,26 +83,28 @@ required_global_attrs = dict(
 
 
 # optional global attributes (root-group)
-optional_root_attrs = [
-    ("site_name", "name of site where data were gathered"),
-    ("scan_name", "name of scan strategy used, if applicable"),
-    ("scan_id", "scan strategy id, if applicable. assumed 0 if missing"),
-    (
-        "ray_times_increase",
+optional_root_attrs = dict(
+    [
+        ("site_name", "name of site where data were gathered"),
+        ("scan_name", "name of scan strategy used, if applicable"),
+        ("scan_id", "scan strategy id, if applicable. assumed 0 if missing"),
         (
-            "'true' or 'false', assumed 'true' if missing. "
-            "This is set to true if ray times increase monotonically "
-            "throughout all of the sweeps in the volume."
+            "ray_times_increase",
+            (
+                "'true' or 'false', assumed 'true' if missing. "
+                "This is set to true if ray times increase monotonically "
+                "throughout all of the sweeps in the volume."
+            ),
         ),
-    ),
-    (
-        "simulated",
         (
-            "'true' or 'false', assumed 'false' if missing. "
-            "data in this file are simulated"
+            "simulated",
+            (
+                "'true' or 'false', assumed 'false' if missing. "
+                "data in this file are simulated"
+            ),
         ),
-    ),
-]
+    ]
+)
 
 #: required global variables (root-group)
 required_root_vars = {
@@ -112,16 +114,22 @@ required_root_vars = {
     "latitude",
     "longitude",
     "altitude",
-    "platform_type",
-    "instrument_type",
+    "sweep_group_name",
+    "sweep_fixed_angle",
 }
 
 #: optional global attributes (root-group)
-optional_root_vars = {
-    "altitude_agl",
-    "primary_axis",
-    "status_str",
-}
+optional_root_vars = dict(
+    [
+        ("platform_type", None),
+        ("instrument_type", None),
+        ("primary_axis", None),
+        ("altitude_agl", None),
+        ("frequency", None),  # cfradial 2.0
+        ("status_str", None),  # cfrdadial 2.1
+        ("status_xml", "status_str"),  # cfradial 2.0
+    ]
+)
 
 #: sweep-group coordinate variables
 sweep_coordinate_vars = {
@@ -136,7 +144,7 @@ required_sweep_metadata_vars = {
     "sweep_mode",
     "follow_mode",
     "prt_mode",
-    "fixed_angle",
+    "sweep_fixed_angle",
     "azimuth",
     "elevation",
 }
@@ -210,6 +218,110 @@ non_standard_sweep_dataset_vars = {
     "VR",
 }
 
+# root metadata groups
+#: radar_parameters subgroup
+radar_parameters_subgroup = dict(
+    [
+        ("radar_antenna_gain_h", None),
+        ("radar_antenna_gain_v", None),
+        ("radar_beam_width_h", None),
+        ("radar_beam_width_v", None),
+        ("radar_receiver_bandwidth", None),  # cfradial2.1
+        ("radar_rx_bandwidth", "radar_receiver_bandwidth"),  # cfradial1.X
+    ]
+)
+
+#: radar_calibration subgroup
+radar_calibration_subgroup = dict(
+    [
+        ("calib_index", None),
+        ("time", None),
+        ("pulse_width", None),
+        ("antenna_gain_h", None),
+        ("antenna_gain_v", None),
+        ("xmit_power_h", None),
+        ("xmit_power_v", None),
+        ("two_way_waveguide_loss_h", None),
+        ("two_way_waveguide_loss_v", None),
+        ("two_way_radome_loss_h", None),
+        ("two_way_radome_loss_v", None),
+        ("receiver_mismatch_loss", None),
+        ("receiver_mismatch_loss_h", None),
+        ("receiver_mismatch_loss_v", None),
+        ("radar_constant_h", None),
+        ("radar_constant_v", None),
+        ("probert_jones_correction", None),
+        ("dielectric_factor_used", None),
+        ("noise_hc", None),
+        ("noise_vc", None),
+        ("noise_hx", None),
+        ("noise_vx", None),
+        ("receiver_gain_hc", None),
+        ("receiver_gain_vc", None),
+        ("receiver_gain_hx", None),
+        ("receiver_gain_vx", None),
+        ("base_1km_hc", None),
+        ("base_dbz_1km_hc", "base_1km_hc"),  # cfradial1
+        ("base_1km_vc", None),
+        ("base_dbz_1km_vc", "base_1km_vc"),  # cfradial1
+        ("base_1km_hx", None),
+        ("base_dbz_1km_hx", "base_1km_hx"),  # cfradial1
+        ("base_1km_vx", None),
+        ("base_dbz_1km_vx", "base_1km_vx"),  # cfradial1
+        ("sun_power_hc", None),
+        ("sun_power_vc", None),
+        ("sun_power_hx", None),
+        ("sun_power_vx", None),
+        ("noise_source_power_h", None),
+        ("noise_source_power_v", None),
+        ("power_measure_loss_h", None),
+        ("power_measure_loss_v", None),
+        ("coupler_forward_loss_h", None),
+        ("coupler_forward_loss_v", None),
+        ("zdr_correction", None),
+        ("ldr_correction_h", None),
+        ("ldr_correction_v", None),
+        ("system_phidp", None),
+        ("test_power_h", None),
+        ("test_power_v", None),
+        ("receiver_slope_hc", None),
+        ("receiver_slope_vc", None),
+        ("receiver_slope_hx", None),
+        ("receiver_slope_vx", None),
+    ]
+)
+
+#: georeferencing_correction subgroup
+georeferencing_correction_subgroup = dict(
+    [
+        ("azimuth_correction", None),
+        ("elevation_correction", None),
+        ("range_correction", None),
+        ("longitude_correction", None),
+        ("latitude_correction", None),
+        ("pressure_altitude_correction", None),
+        ("altitude_correction", "radar_altitude_correction"),  # cfradial1
+        ("radar_altitude_correction", None),
+        (
+            "eastward_velocity_correction",
+            "eastward_ground_speed_correction",
+        ),  # cfradial1
+        ("eastward_ground_speed_correction", None),
+        (
+            "northward_velocity_correction",
+            "northward_ground_speed_correction",
+        ),  # cfradial1
+        ("northward_ground_speed_correction", None),
+        ("vertical_velocity_correction", None),
+        ("heading_correction", None),
+        ("roll_correction", None),
+        ("pitch_correction", None),
+        ("drift_correction", None),
+        ("rotation_correction", None),
+        ("tilt_correction", None),
+    ]
+)
+
 #: required range attributes
 range_attrs = {
     "units": "meters",
@@ -233,29 +345,8 @@ frequency_attrs = {
     "units": "s-1",
 }
 
-#:
-lon_attrs = {
-    "long_name": "longitude",
-    "units": "degrees_east",
-    "standard_name": "longitude",
-}
 
-#:
-lat_attrs = {
-    "long_name": "latitude",
-    "units": "degrees_north",
-    "positive": "up",
-    "standard_name": "latitude",
-}
-
-#:
-alt_attrs = {
-    "long_name": "altitude",
-    "units": "meters",
-    "standard_name": "altitude",
-}
-
-#:
+#: required moment attributes
 moment_attrs = {"standard_name", "long_name", "units"}
 
 # todo: align this with sweep_dataset_vars


### PR DESCRIPTION
This is an attempt to increase the amount of metadata which is imported into the internal DataTree-structure at the right places CfRadial2 is expecting it.

Takes over from: #43 

- refactor internal cfradial1 reader to extract CfRadial2 groups from cfradial1 Dataset
- enhance the model with subgroup metadata
- fix tests
- add Notebook showing the transformation from CfRadial1 to CfRadial2
- fix Notebooks and tests

ToDo:

- Make the above happen also for sweep-subgroups (need to have example files).
- Make the above happen also for other sources (`ODIM_H5`, etc), the transformation might not be that easy, though. But in any case a notebook writeup showing the transformation would help developers and users to look behind the scenes.  