### PR TITLE
CfRadial1 reader kwargs refactor, add to_cfradial2 exporter 

### DIFF
--- a/examples/notebooks/CfRadial1.ipynb
+++ b/examples/notebooks/CfRadial1.ipynb
@@ -57,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\")\n",
+    "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\", first_dim=\"time\")\n",
     "\n",
     "with xr.set_options(display_expand_data_vars=True, display_max_rows=1000):\n",
     "    display(ds)"
@@ -137,6 +137,34 @@
   },
   {
    "cell_type": "markdown",
+   "id": "a53f70a0-d9ba-46e8-b12b-9963cd47f4de",
+   "metadata": {},
+   "source": [
+    "Another option would be to load the Dataset with kwarg `first_dim=\"auto\"`, the default. Then we get back the Dataset with the corresponding dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53ab485e-2aa1-496d-9656-847483bec39a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5389dd95-3e10-4eb3-9495-2acc6b26e18d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.DBZ.plot()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "4e8378a1-3fde-4eba-9a9d-c6e705d901d3",
    "metadata": {},
    "source": [
@@ -159,7 +187,9 @@
    "id": "096daea4-e94d-49d3-9c3d-cb28d866c744",
    "metadata": {},
    "source": [
-    "### Plot Sweep Range vs. Time"
+    "### Plot Sweep Range vs. Time\n",
+    "\n",
+    "Select Sub-Datasets from DataTree and plot."
    ]
   },
   {
@@ -170,24 +200,6 @@
    "outputs": [],
    "source": [
     "dtree[\"sweep_0\"].ds.DBZ.plot()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "ba98ffd2-4c86-4833-8fb3-080c71d48fb9",
-   "metadata": {},
-   "source": [
-    "### Plot Sweep Range vs. Azimuth"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9be803a2-0979-4f49-9ea1-d7aaf2dd2a16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dtree[\"sweep_0\"].ds.DBZ.sortby(\"azimuth\").plot(y=\"azimuth\")"
    ]
   }
  ],
@@ -202,7 +214,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/CfRadial1_Model_Transformation.ipynb
+++ b/examples/notebooks/CfRadial1_Model_Transformation.ipynb
@@ -21,6 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
     "import xarray as xr\n",
     "import xradar as xd\n",
     "import datatree as xt\n",
@@ -295,11 +296,11 @@
    "id": "7f4f2c1c-5961-43f6-8c40-cbe796dd12dd",
    "metadata": {},
    "source": [
-    "Again we use a convenience function to extract the different sweep groups.  We can call this function with one kwarg:\n",
+    "Again we use a convenience function to extract the different sweep groups.  We can call this function with kwargs:\n",
     "\n",
     "- `optional=False` - only mandatory data and metadata is imported, defaults to `True`\n",
-    "- `first_dim=\"auto` - return first dimension either as `azimuth` (PPI) or `elevation` (RHI), defaults to `time`\n",
-    "- `site_coords=True` - add radar site coordinates to the Dataset, defaults to `False`\n",
+    "- `first_dim=\"time` - return first dimension as `time`, defaults to`auto` (return either as `azimuth` (PPI) or `elevation` (RHI)to `time`\n",
+    "- `site_coords=False` - do not add radar site coordinates to the Sweep-Dataset, defaults to `True`\n",
     "\n",
     "#### Examining first sweep with default kwargs."
    ]
@@ -341,7 +342,7 @@
    "id": "32652409",
    "metadata": {},
    "source": [
-    "#### `optional=False` and `site_coords=True`"
+    "#### `optional=False` and `site_coords=False`"
    ]
   },
   {
@@ -352,7 +353,7 @@
    "outputs": [],
    "source": [
     "sweeps = xd.io.backends.cfradial1._get_sweep_groups(\n",
-    "    ds, optional=False, site_coords=True\n",
+    "    ds, optional=False, site_coords=False\n",
     ")\n",
     "with xr.set_options(display_expand_data_vars=True):\n",
     "    display(sweeps[\"sweep_0\"])"
@@ -374,7 +375,7 @@
    "outputs": [],
    "source": [
     "sweeps = xd.io.backends.cfradial1._get_sweep_groups(\n",
-    "    ds, optional=False, site_coords=True, first_dim=\"auto\"\n",
+    "    ds, optional=False, site_coords=False, first_dim=\"time\"\n",
     ")\n",
     "with xr.set_options(display_expand_data_vars=True):\n",
     "    display(sweeps[\"sweep_0\"])"
@@ -437,10 +438,18 @@
   },
   {
    "cell_type": "markdown",
+   "id": "97ee3558-d138-4669-8bcf-91cb493669af",
+   "metadata": {},
+   "source": [
+    "#### Roundtrip with `to_netcdf`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "55515cf9",
    "metadata": {},
    "source": [
-    "Write DataTree to netCDF4 file, reopen and compare with source."
+    "Write DataTree to netCDF4 file, reopen and compare with source. This just tets if roundtripping the DataTree works."
    ]
   },
   {
@@ -450,7 +459,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtree.to_netcdf(\"test_dtree.nc\")"
+    "outfile = \"test_dtree.nc\"\n",
+    "if os.path.exists(outfile):\n",
+    "    os.unlink(outfile)\n",
+    "dtree.to_netcdf(outfile)"
    ]
   },
   {
@@ -460,7 +472,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtree2 = xt.open_datatree(\"test_dtree.nc\")\n",
+    "dtree2 = xt.open_datatree(outfile)\n",
     "with xr.set_options(display_expand_data_vars=True, display_expand_attrs=True):\n",
     "    display(dtree2)"
    ]
@@ -482,9 +494,7 @@
    "id": "54aaa127",
    "metadata": {},
    "source": [
-    "### Datasets\n",
-    "\n",
-    "Using xarray.open_dataset and the cfradial1-backend we can easily load specific groups side-stepping the DataTree.  Can be parameterized using kwargs."
+    "#### Roundtrip with `xradar.io.to_cfradial2`"
    ]
   },
   {
@@ -494,7 +504,74 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(filename, group=\"sweep_1\", engine=\"cfradial1\", first_dim=\"auto\")\n",
+    "dtree3 = xd.io.open_cfradial1_datatree(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "003efee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(dtree3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42b00295-08c6-4b03-b293-69fb141239f7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outfile = \"test_cfradial2.nc\"\n",
+    "if os.path.exists(outfile):\n",
+    "    os.unlink(outfile)\n",
+    "xd.io.to_cfradial2(dtree3, outfile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de63c0fc-7d9f-443d-b802-e1c903930142",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dtree4 = xt.open_datatree(\"test_cfradial2.nc\")\n",
+    "with xr.set_options(display_expand_data_vars=True, display_expand_attrs=True):\n",
+    "    display(dtree4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8753ef39-f4eb-48c8-b084-e3e50aee337a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for grp in dtree3.groups:\n",
+    "    print(grp)\n",
+    "    xr.testing.assert_equal(dtree3[grp].ds, dtree4[grp].ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fa2c9b84-ce4a-46fb-bd2d-54bcc683f4e1",
+   "metadata": {},
+   "source": [
+    "### Datasets\n",
+    "\n",
+    "Using xarray.open_dataset and the cfradial1-backend we can easily load specific groups side-stepping the DataTree.  Can be parameterized using kwargs."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e5e50281-6f8b-4400-b4c9-fb17d07eac24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(filename, group=\"sweep_1\", engine=\"cfradial1\", first_dim=\"time\")\n",
     "with xr.set_options(display_expand_data_vars=True):\n",
     "    display(ds.load())"
    ]
@@ -502,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "003efee0",
+   "id": "679d0844-6852-43c4-a2ee-78ccd7d8e943",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +611,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.10.6"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/CfRadial1_Model_Transformation.ipynb
+++ b/examples/notebooks/CfRadial1_Model_Transformation.ipynb
@@ -7,7 +7,7 @@
    "source": [
     "# CfRadial1 to CfRadial2 -  A data model transformation\n",
     "\n",
-    "In this notebook we show how to transform the CfRadial1 Data model to a CfRadial2 representation. \n",
+    "In this notebook we show how to transform the CfRadial1 Data model to a CfRadial2 representation.\n",
     "\n",
     "We use some internal functions to show how xradar is working inside.\n",
     "\n",
@@ -78,7 +78,7 @@
    "source": [
     "## Extract CfRadial2 Groups and Subgroups\n",
     "\n",
-    "Now as we have the CfRadial1 Dataset we can work towards extracting the CfRadial2 groups and subgroups. "
+    "Now as we have the CfRadial1 Dataset we can work towards extracting the CfRadial2 groups and subgroups."
    ]
   },
   {
@@ -91,7 +91,17 @@
     "The following sections present the details of the information in the top-level (root) group of the\n",
     "data set.\n",
     "\n",
-    "We use a convenience function to extract the CfRadial2 root group from the CfRadial1 Dataset. If we call with `optional=False` only mandatory data and metadata is imported."
+    "We use a convenience function to extract the CfRadial2 root group from the CfRadial1 Dataset. We can call this function with one kwarg:\n",
+    "\n",
+    "- `optional=False` - only mandatory data and metadata is imported, defaults to True"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f4f3ff2f",
+   "metadata": {},
+   "source": [
+    "#### optional=True"
    ]
   },
   {
@@ -106,6 +116,14 @@
     "    display_expand_data_vars=True, display_expand_attrs=True, display_max_rows=1000\n",
     "):\n",
     "    display(root.load())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7459f970",
+   "metadata": {},
+   "source": [
+    "#### optional=False"
    ]
   },
   {
@@ -129,7 +147,7 @@
    "source": [
     "### Extract Root-Group metadata groups\n",
     "\n",
-    "The Cfradial2 Data Model has a notion of root group metadata groups. Those groups provide additional metadata covering other aspects of the radar system. \n",
+    "The Cfradial2 Data Model has a notion of root group metadata groups. Those groups provide additional metadata covering other aspects of the radar system.\n",
     "\n",
     "#### The radar_parameters sub-group\n",
     "\n",
@@ -165,16 +183,6 @@
     "    ds, xd.model.radar_parameters_subgroup\n",
     ")\n",
     "display(radar_parameters.load())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "0fa140a9",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "radar_parameters.to_netcdf(\"radar_parameters.nc\")"
    ]
   },
   {
@@ -215,7 +223,8 @@
    "source": [
     "radar_calibration = xd.io.backends.cfradial1._get_radar_calibration(ds)\n",
     "with xr.set_options(display_expand_data_vars=True):\n",
-    "    display(radar_calibration.load())"
+    "    if radar_calibration:\n",
+    "        display(radar_calibration.load())"
    ]
   },
   {
@@ -286,7 +295,13 @@
    "id": "7f4f2c1c-5961-43f6-8c40-cbe796dd12dd",
    "metadata": {},
    "source": [
-    "Again we use a convenience function to extract the different sweep groups. Examining first sweep."
+    "Again we use a convenience function to extract the different sweep groups.  We can call this function with one kwarg:\n",
+    "\n",
+    "- `optional=False` - only mandatory data and metadata is imported, defaults to `True`\n",
+    "- `first_dim=\"auto` - return first dimension either as `azimuth` (PPI) or `elevation` (RHI), defaults to `time`\n",
+    "- `site_coords=True` - add radar site coordinates to the Dataset, defaults to `False`\n",
+    "\n",
+    "#### Examining first sweep with default kwargs."
    ]
   },
   {
@@ -306,9 +321,73 @@
    "id": "38b326e1",
    "metadata": {},
    "source": [
+    "#### Examining first sweep with `optional=False`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "729e1ee3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweeps = xd.io.backends.cfradial1._get_sweep_groups(ds, optional=False)\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(sweeps[\"sweep_0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "32652409",
+   "metadata": {},
+   "source": [
+    "#### `optional=False` and `site_coords=True`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "deaaa18e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweeps = xd.io.backends.cfradial1._get_sweep_groups(\n",
+    "    ds, optional=False, site_coords=True\n",
+    ")\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(sweeps[\"sweep_0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "65a43c95",
+   "metadata": {},
+   "source": [
+    "#### `optional=False`, `site_coords=True` and `first_dim=\"auto\"`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef477a6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sweeps = xd.io.backends.cfradial1._get_sweep_groups(\n",
+    "    ds, optional=False, site_coords=True, first_dim=\"auto\"\n",
+    ")\n",
+    "with xr.set_options(display_expand_data_vars=True):\n",
+    "    display(sweeps[\"sweep_0\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e320f119",
+   "metadata": {},
+   "source": [
     "## Read as CfRadial2 data representation\n",
     "\n",
-    "xradar provides two easy ways to retrieve the CfRadial1 data as CfRadial2 groups. \n",
+    "xradar provides two easy ways to retrieve the CfRadial1 data as CfRadial2 groups.\n",
     "\n",
     "### DataTree\n",
     "\n",
@@ -405,7 +484,7 @@
    "source": [
     "### Datasets\n",
     "\n",
-    "Using xarray.open_dataset and the cfradial1-backend we can easily load specific groups side-stepping the DataTree."
+    "Using xarray.open_dataset and the cfradial1-backend we can easily load specific groups side-stepping the DataTree.  Can be parameterized using kwargs."
    ]
   },
   {
@@ -438,9 +517,9 @@
    "source": [
     "## Conclusion\n",
     "\n",
-    "CfRadial1 and CfRadial2 are based on the same principles with slightly different data representation. Nevertheless the conversion is relatively straighforward as has been shown here. \n",
+    "CfRadial1 and CfRadial2 are based on the same principles with slightly different data representation. Nevertheless the conversion is relatively straighforward as has been shown here.\n",
     "\n",
-    "As the implementation with the cfradial1 xarray backend on one hand and the DataTree on the other hand is very versatile users can pick the most usable approach for their workflows. "
+    "As the implementation with the cfradial1 xarray backend on one hand and the DataTree on the other hand is very versatile users can pick the most usable approach for their workflows.\n"
    ]
   }
  ],
@@ -455,7 +534,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/examples/notebooks/CfRadial1_full.ipynb
+++ b/examples/notebooks/CfRadial1_full.ipynb
@@ -68,9 +68,7 @@
    "source": [
     "## backend_kwargs\n",
     "\n",
-    "The cfradial1 backend has only one specific kwarg for now, `first_dim`.\n",
-    "\n",
-    "`first_dim` can be either `time` (default) or `auto`. On `auto` the first dimension is gathered from the sweep metadata and will be either `azimuth` or `elevation`. `first_dim` can be provided as `**kwargs` or inside `backend_kwargs`."
+    "The cfradial1 backend can be parameterized via kwargs. Please observe the possibilities below."
    ]
   },
   {
@@ -90,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\", first_dim=\"auto\")\n",
+    "ds = xr.open_dataset(filename, group=\"sweep_0\", engine=\"cfradial1\", first_dim=\"time\")\n",
     "display(ds)"
    ]
   },
@@ -102,7 +100,7 @@
    "outputs": [],
    "source": [
     "ds = xr.open_dataset(\n",
-    "    filename, group=\"sweep_1\", engine=\"cfradial1\", backend_kwargs=dict(first_dim=\"auto\")\n",
+    "    filename, group=\"sweep_1\", engine=\"cfradial1\", backend_kwargs=dict(first_dim=\"time\")\n",
     ")\n",
     "display(ds)"
    ]
@@ -134,7 +132,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtree = xd.io.open_cfradial1_datatree(filename, first_dim=\"auto\", sweep=0)\n",
+    "dtree = xd.io.open_cfradial1_datatree(\n",
+    "    filename, first_dim=\"auto\", optional=False, sweep=0\n",
+    ")\n",
     "display(dtree)"
    ]
   },
@@ -174,7 +174,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.13"
   }
  },
  "nbformat": 4,

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -23,7 +23,7 @@ from xradar.model import (
 
 
 def test_open_cfradial1_datatree(cfradial1_file):
-    dtree = open_cfradial1_datatree(cfradial1_file)
+    dtree = open_cfradial1_datatree(cfradial1_file, first_dim="time", site_coords=False)
     attrs = dtree.attrs
 
     # root_attrs
@@ -80,14 +80,14 @@ def test_open_cfradial1_datatree(cfradial1_file):
 def test_open_cfradial1_dataset(cfradial1_file):
     # open first sweep group
     ds = xr.open_dataset(cfradial1_file, group="sweep_0", engine="cfradial1")
-    assert list(ds.dims) == ["time", "range"]
+    assert list(ds.dims) == ["azimuth", "range"]
     assert set(ds.data_vars) & (
         sweep_dataset_vars | non_standard_sweep_dataset_vars
     ) == {"DBZ", "VR"}
 
     # open last sweep group
     ds = xr.open_dataset(cfradial1_file, group="sweep_8", engine="cfradial1")
-    assert list(ds.dims) == ["time", "range"]
+    assert list(ds.dims) == ["azimuth", "range"]
     assert set(ds.data_vars) & (
         sweep_dataset_vars | non_standard_sweep_dataset_vars
     ) == {"DBZ", "VR"}

--- a/xradar/io/export/__init__.py
+++ b/xradar/io/export/__init__.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# Copyright (c) 2022, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
+"""
+Data Export
+===========
+
+.. toctree::
+    :maxdepth: 4
+
+.. automodule:: xradar.io.export.cfradial2
+.. automodule:: xradar.io.export.odim
+
+"""
+
+from .cfradial2 import *  # noqa
+from .odim import *  # noqa
+
+__all__ = [s for s in dir() if not s.startswith("_")]

--- a/xradar/io/export/cfradial2.py
+++ b/xradar/io/export/cfradial2.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python
+# Copyright (c) 2022, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
+"""
+
+CfRadial2 output
+================
+
+This sub-module contains the writer for export of CfRadial2-based radar
+data.
+
+Code ported from wradlib.
+
+Example::
+
+    import xradar as xd
+    dtree = xd.io.to_cfradial2(dtree, filename)
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   {}
+
+"""
+
+__all__ = [
+    "to_cfradial2",
+]
+
+__doc__ = __doc__.format("\n   ".join(__all__))
+
+from importlib.metadata import version
+
+from datatree import DataTree
+
+from ...model import conform_cfradial2_sweep_group
+from ...util import has_import
+
+
+def to_cfradial2(dtree, filename, engine=None, timestep=None):
+    """Save DataTree to CfRadial2 compliant file.
+
+    Parameters
+    ----------
+    dtree : DataTree
+        DataTree with CfRadial2 groups.
+    filename : str
+        output filename
+
+    Keyword Arguments
+    ----------------
+    timestep : int
+        timestep of wanted volume, currently not used
+    engine : str
+        Either `netcdf4` or `h5netcdf`.
+    """
+    if engine is None:
+        if has_import("netCDF4"):
+            engine == "netcdf4"
+        elif has_import("h5netcdf"):
+            engine == "h5netcdf"
+        else:
+            raise ImportError(
+                "xradar: ``netCDF4`` or ``h5netcdf`` needed to perform this operation."
+            )
+
+    # iterate over DataTree and make subgroups cfradial2 compliant
+    for grp in dtree.groups:
+        if "sweep" in grp:
+            dtree[grp] = DataTree(
+                conform_cfradial2_sweep_group(
+                    dtree[grp].to_dataset(), optional=False, dim0="azimuth"
+                )
+            )
+
+    root = dtree["/"].to_dataset()
+    # fix Conventions
+    root.attrs["Conventions"] = "Cf/Radial"
+    root.attrs["version"] = "2.0"
+    # add xradar version to history
+    xradar_version = version('xradar')
+    root.attrs["history"] += f": xradar v{xradar_version} CfRadial2 export"
+
+    # write DataTree
+    dtree.to_netcdf(filename, engine=engine)

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -8,7 +8,7 @@ ODIM_H5 output
 ==============
 
 This sub-module contains the writer for export of ODIM_H5-based radar
-data into.
+data.
 
 Code ported from wradlib.
 
@@ -36,7 +36,7 @@ import datetime as dt
 import h5py
 import numpy as np
 
-from ..model import required_sweep_metadata_vars
+from ...model import required_sweep_metadata_vars
 
 
 def _write_odim(source, destination):


### PR DESCRIPTION
1. CfRadial1 reader kwarg refactor:

```python
"""
    first_dim : str
        Can be ``time`` or ``auto`` first dimension. If set to ``auto``,
        first dimension will be either ``azimuth`` or ``elevation`` depending on
        type of sweep. Defaults to ``auto``.
    optional : bool
        Import optional mandatory data and metadata, defaults to ``True``.
    site_coords : bool
        Attach radar site-coordinates to Dataset, defaults to ``True``.
"""
```

```python
swp = xr.open_dataset(fname, group="sweep_0", site_coords=False, optional=False, first_dim="time", engine="cfradial1")
```

These kwargs are available for DataTree loading, as well as Dataset-loading.

2. Add `to_cfradial2` export function
    - added functionality to model to conform a sweep dataset, such that only CfRadial2 conforming data is written (needs extension and enhancement)

Todo: Add tests for the introduced functionality.

closes: #48 

~~This PR also updates pre-commit hooks:~~

~~- add nbstripout, to clean notebooks before committing~~
~~- remove the `double-quote-string-fixer`, as it contradicts with black-formatting~~ 
~~- remove the skip-string-normalization from black-formatting~~ 
~~- format with black~~ 

~~I can split this into two, if necessary. Need to make sure to do rebase-merge otherwise.~~
This part moved to #50 