### PR TITLE
ENH: add IRIS DB_VELC decoding and tests

### DIFF
--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -79,6 +79,14 @@ def decode_array():
     )
 
 
+def test_decode_velc():
+    data = [0, 1, 2, 128, 129, 254, 255]
+    np.testing.assert_array_almost_equal(
+        iris.decode_array(data, scale=127 / 75.0, offset=-1, offset2=-75, mask=0.0),
+        [np.inf, -75.0, -74.409449, 0.0, 0.590551, 74.409449, 75.0],
+    )
+
+
 def test_decode_kdp():
     np.testing.assert_array_almost_equal(
         iris.decode_kdp(np.arange(-5, 5, dtype="int8"), wavelength=10.0),

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -1881,7 +1881,20 @@ SIGMET_DATA_TYPES = OrderedDict(
             },
         ),
         # Corrected Velocity (1 byte)
-        (17, {"name": "DB_VELC", "dtype": "uint8", "func": None}),
+        (
+            17,
+            {
+                "name": "DB_VELC",
+                "dtype": "uint8",
+                "func": decode_array,
+                "fkw": {
+                    "offset": -1,
+                    "scale": 253.0 / 150,
+                    "offset2": -75,
+                    "mask": 0.0,
+                },
+            },
+        ),
         # SQI (1 byte)
         (
             18,


### PR DESCRIPTION
closes #78 

Unfortunately the description in the docs is inaccurate. I've taken a reasonable approach to decode as probably intended.

> **4.4.42 1-byte Unfolded Velocity Format (DB_VELC)**
>
> This is the mean radial velocity corrected for both Nyquist folding and fall speed. It is scaled
> to cover a fixed span of +/- 75 meters/second. In data product files, the value 255 is used to
> indicate area not scanned.
> 
> 0 | Velocity data not available at this range
> 1 | -75.0 m/s (towards the radar)
> 2 | -74.4 m/s
> 128 | Zero velocity
> 129 | +0.6 m/s
> 254 | +75.0 m/s (away from the radar)
> 255 | Area not scanned

This will now be decoded to:

[ inf, -75., -74.409449,  0.,   0.590551, 74.409449,  75.]


