### PR TITLE
REL: 0.0.12

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -15,7 +15,7 @@ authors:
   family-names: Mühlbauer
   affiliation: University Bonn
   orcid: https://orcid.org/0000-0001-6599-1034
-version: 0.0.11
-date-released: 2023-02-06
+version: 0.0.12
+date-released: 2023-02-09
 repository-code: https://github.com/openradar/xradar
 license: MIT

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,11 @@
 # History
 
+## 0.0.12 (2023-02-09)
+
+* ENH: add IRIS ``DB_VELC`` decoding and tests ({issue}`78`), ({pull}`83`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: furuno backend inconsistencies ({issue}`77`), ({pull}`82`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: ODIM_H5 backend inconsistencies ({issue}`80`), ({pull}`81`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+
 ## 0.0.11 (2023-02-06)
 
 * fix ``_Undetect``/``_FillValue`` in odim writer ({pull}`71`) by [@kmuehlbauer](https://github.com/kmuehlbauer)


### PR DESCRIPTION
Moving forward with releasing the latest changes.

Let's keep up momentum in getting `xradar` as a first class citizen into `wradlib`. :rocket: 