### PR TITLE
FIX: only skip setting cf-attributes if both gain and offset are unused

### DIFF
--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -350,7 +350,7 @@ class _OdimH5NetCDFMetadata:
         what = self._root[self._group]["what"].attrs
         gain = what.get("gain", 1.0)
         offset = what.get("offset", 0.0)
-        if gain != 1.0 and offset != 0.0:
+        if not (gain == 1.0 and offset == 0.0):
             attrs["scale_factor"] = gain
             attrs["add_offset"] = offset
             attrs["_FillValue"] = what.get("nodata", None)


### PR DESCRIPTION
So this is unfortunate, as this slipped through the cracks. But anyway version numbers are cheap. :man_facepalming: 

