### PR TITLE
ENH: add `spatial_ref` with `pyproj` when georeferencing, add/adapt methods/tests

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -10,24 +10,23 @@ repos:
       - id: debug-statements
       - id: mixed-line-ending
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.31.0
+    rev: v3.3.1
     hooks:
       - id: pyupgrade
         args:
           - '--py38-plus'
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.6.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
-        args:
-          - '--extra-keys "metadata.kernelspec"'
+        args: ['--extra-keys', 'metadata.kernelspec cell.metadata.pycharm cell.metadata.tags']
   - repo: https://github.com/charliermarsh/ruff-pre-commit
-    rev: 'v0.0.239'
+    rev: 'v0.0.246'
     hooks:
       - id: ruff
-        args: [ "--fix" ]
+        args: ['--fix']
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
       - id: black-jupyter

--- a/ci/unittests.yml
+++ b/ci/unittests.yml
@@ -2,7 +2,8 @@ name: wradlib-unittests
 channels:
   - conda-forge
 dependencies:
-  - python>=3.7
+  - python>=3.9
+  - cartopy
   - codecov
   - coverage
   - dask
@@ -15,6 +16,7 @@ dependencies:
   - notebook
   - numpy
   - pip
+  - pyproj
   - pytest
   - pytest-cov
   - pytest-doctestplus

--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -70,4 +70,3 @@ Internal Representation: {py:class}`xarray:xarray.DataArray`
 [FM301]: https://wmoomm.sharepoint.com/:b:/s/wmocpdb/EVcEDwHwf6FJtB6anuyBH3QBgA5bE_Uz9jI4FaSkAyowSg?e=jcazi4
 [Xarray]: https://docs.xarray.dev
 [xarray-datatree]: https://xarray-datatree.readthedocs.io
-

--- a/environment.yml
+++ b/environment.yml
@@ -15,9 +15,11 @@ dependencies:
   - h5py
   - lat_lon_parser
   - netCDF4
+  - pyproj
   - xarray
   - xarray-datatree>=0.0.10
   - xmltodict
+  - cartopy
   - dask
   - matplotlib-base
   - scipy

--- a/examples/notebooks/CfRadial1.ipynb
+++ b/examples/notebooks/CfRadial1.ipynb
@@ -64,9 +64,7 @@
   {
    "cell_type": "markdown",
    "id": "8d754b45-a02a-4e08-be5b-300d184441b6",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Plot Time vs. Azimuth\n",
     "\n",

--- a/examples/notebooks/GAMIC.ipynb
+++ b/examples/notebooks/GAMIC.ipynb
@@ -250,11 +250,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/examples/notebooks/Iris.ipynb
+++ b/examples/notebooks/Iris.ipynb
@@ -274,11 +274,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/examples/notebooks/Rainbow.ipynb
+++ b/examples/notebooks/Rainbow.ipynb
@@ -65,9 +65,7 @@
   {
    "cell_type": "markdown",
    "id": "01ec8c90-2da8-46ae-a0b5-0e1792a79bbe",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "source": [
     "### Plot Time vs. Azimuth\n",
     "\n",

--- a/examples/notebooks/angle_reindexing.ipynb
+++ b/examples/notebooks/angle_reindexing.ipynb
@@ -134,9 +134,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ce60e202-da51-41f2-9950-8e849f8db03b",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds_in = xr.concat(\n",
@@ -176,9 +174,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c46977b6-864d-4d75-8dba-c64f9599f2a7",
-   "metadata": {
-    "tags": []
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ds_out = fix_angle(ds_in)\n",
@@ -259,11 +255,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/examples/notebooks/plot-ppi.ipynb
+++ b/examples/notebooks/plot-ppi.ipynb
@@ -138,11 +138,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/examples/notebooks/plot-ppi.ipynb
+++ b/examples/notebooks/plot-ppi.ipynb
@@ -30,6 +30,18 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "02f07bb2-d1ad-40c2-9a32-3795de327003",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import pyproj\n",
+    "import cartopy"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "id": "100584b5-d600-4f93-980b-6c1dde9335a8",
    "metadata": {},
@@ -83,7 +95,7 @@
    "metadata": {},
    "source": [
     "### Georeference Accessor\n",
-    "If you prefer the accesor (`.xradar.georefence()`), this is how you would add georeference information to your radar object."
+    "If you prefer the accessor (`.xradar.georefence()`), this is how you would add georeference information to your radar object."
    ]
   },
   {
@@ -95,6 +107,24 @@
    "source": [
     "radar = radar.xradar.georeference()\n",
     "display(radar)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "53683020-5503-4be6-8eb5-2fc40c340ef3",
+   "metadata": {},
+   "source": [
+    "Please observe, that the additional coordinates `x`, `y`, `z` have been added to the dataset. This will also add `spatial_ref` CRS information on the used Azimuthal Equidistant Projection."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a2579869-1e4f-48d2-93eb-d57084d78fe6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar[\"sweep_0\"]"
    ]
   },
   {
@@ -114,7 +144,7 @@
    "outputs": [],
    "source": [
     "radar = xd.georeference.get_x_y_z_tree(radar)\n",
-    "display(radar)"
+    "display(radar[\"sweep_0\"])"
    ]
   },
   {
@@ -123,7 +153,10 @@
    "metadata": {},
    "source": [
     "## Plot our Data\n",
-    "Now, let's create our PPI plot!"
+    "\n",
+    "### Plot simple PPI\n",
+    "\n",
+    "Now, let's create our PPI plot! We just use the newly created 2D-coordinates `x` and `y` to create a meshplot."
    ]
   },
   {
@@ -134,6 +167,55 @@
    "outputs": [],
    "source": [
     "radar[\"sweep_0\"][\"DBZ\"].plot(x=\"x\", y=\"y\", cmap=\"Spectral_r\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "505e3ad9-ff77-4d7c-b09e-28b87c3328b5",
+   "metadata": {},
+   "source": [
+    "### Plot PPI on map with cartopy\n",
+    "\n",
+    "If you have `cartopy` installed, you can easily plot on maps. We first have to extract the CRS from the dataset and to wrap it in a `cartopy.crs.Projection`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2b67992f-3ba5-4579-a72e-7303623ccad4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "proj_crs = xd.georeference.get_crs(radar[\"sweep_0\"].ds)\n",
+    "cart_crs = cartopy.crs.Projection(proj_crs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9a3d9c1e-0eac-4fc2-bf0e-c8feffc520c3",
+   "metadata": {},
+   "source": [
+    "Second, we create a matplotlib GeoAxes and a nice map."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9b7680c-9ca2-4b93-8d19-69b9bdb64ae3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure(figsize=(10, 10))\n",
+    "ax = fig.add_subplot(111, projection=cartopy.crs.PlateCarree())\n",
+    "radar[\"sweep_0\"][\"DBZ\"].plot(\n",
+    "    x=\"x\",\n",
+    "    y=\"y\",\n",
+    "    cmap=\"Spectral_r\",\n",
+    "    transform=cart_crs,\n",
+    "    cbar_kwargs=dict(pad=0.075, shrink=0.75),\n",
+    ")\n",
+    "ax.coastlines()\n",
+    "ax.gridlines(draw_labels=True)"
    ]
   }
  ],

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ h5py
 lat_lon_parser
 netCDF4
 numpy
+pyproj
 scipy
 xarray
 xarray-datatree >= 0.0.10

--- a/tests/georeference/test_projection.py
+++ b/tests/georeference/test_projection.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# Copyright (c) 2023, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
+import numpy as np
+import pyproj
+import pytest
+
+import xradar
+from xradar.georeference import add_crs, get_crs, get_earth_radius
+
+
+def test_get_earth_radius():
+    proj_crs = pyproj.CRS(
+        proj="aeqd",
+        datum="WGS84",
+        lon_0=8.7877271,
+        lat_0=46.172541,
+    )
+    ea = get_earth_radius(proj_crs, [20, 22, 24])
+    np.testing.assert_allclose(ea, [6375653.951276, 6375157.677218, 6374623.948138])
+
+
+def test_get_crs():
+    # Create default xradar dataset
+    ds = xradar.model.create_sweep_dataset()
+
+    proj_crs = get_crs(ds)
+    proj_crs_cf = proj_crs.to_cf()
+
+    assert isinstance(proj_crs, pyproj.CRS)
+
+    crs = {
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.314245179,
+        "inverse_flattening": 298.257223563,
+        "reference_ellipsoid_name": "WGS 84",
+        "longitude_of_prime_meridian": 0.0,
+        "prime_meridian_name": "Greenwich",
+        "geographic_crs_name": "unknown",
+        "horizontal_datum_name": "World Geodetic System 1984",
+        "projected_crs_name": "unknown",
+        "grid_mapping_name": "azimuthal_equidistant",
+        "latitude_of_projection_origin": 46.172541,
+        "longitude_of_projection_origin": 8.7877271,
+        "false_easting": 0.0,
+        "false_northing": 0.0,
+    }
+    for key, value in crs.items():
+        if type(value) == float:
+            assert proj_crs_cf[key] == pytest.approx(value)
+        else:
+            assert proj_crs_cf[key] == value
+
+
+def test_write_crs():
+    # Create default xradar dataset
+    ds = xradar.model.create_sweep_dataset()
+
+    ds = add_crs(ds)
+
+    # Make sure spatial_ref has been added with the correct values
+    assert ds.spatial_ref == 0
+    crs = {
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.314245179,
+        "inverse_flattening": 298.257223563,
+        "reference_ellipsoid_name": "WGS 84",
+        "longitude_of_prime_meridian": 0.0,
+        "prime_meridian_name": "Greenwich",
+        "geographic_crs_name": "unknown",
+        "horizontal_datum_name": "World Geodetic System 1984",
+        "projected_crs_name": "unknown",
+        "grid_mapping_name": "azimuthal_equidistant",
+        "latitude_of_projection_origin": 46.172541,
+        "longitude_of_projection_origin": 8.7877271,
+        "false_easting": 0.0,
+        "false_northing": 0.0,
+    }
+    for key, value in crs.items():
+        if type(value) == float:
+            assert ds.spatial_ref.attrs[key] == pytest.approx(value)
+        else:
+            assert ds.spatial_ref.attrs[key] == value

--- a/tests/georeference/test_transforms.py
+++ b/tests/georeference/test_transforms.py
@@ -1,5 +1,9 @@
+#!/usr/bin/env python
+# Copyright (c) 2022-2023, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
 import numpy as np
-import pandas as pd
+import pytest
 from numpy.testing import assert_almost_equal
 
 import xradar
@@ -12,12 +16,12 @@ def test_antenna_to_cartesian():
     elevations = np.arange(0, 50, 5)
 
     # Apply georeferencing to this sample data
-    x, y, z = antenna_to_cartesian(ranges, azimuths, elevations)
+    x, y, z = antenna_to_cartesian(ranges, azimuths, elevations, site_altitude=375.0)
 
     # Check to see if the origin contains all 0s
     assert_almost_equal(x[0], 0)
     assert_almost_equal(y[0], 0)
-    assert_almost_equal(z[0], 0)
+    assert_almost_equal(z[0], 375.0)
 
     # Make sure that at 180 degrees, x is (close to) 0
     assert_almost_equal(x[np.where(azimuths == 180.0)], 0)
@@ -27,29 +31,54 @@ def test_antenna_to_cartesian():
 
 
 def test_get_x_y_z():
-    # Create an empty xradar dataset
-    ds = xradar.model.Dataset()
+    # Create default xradar dataset
+    ds = xradar.model.create_sweep_dataset()
 
-    # Add similar data to before
-    ds["time"] = pd.date_range(start="2018-11-10", end="2018-11-10T00:09:00", freq="T")
-    ds["range"] = np.arange(0, 1000, 100)
-    ds["azimuth"] = ("time", np.arange(0, 300, 30))
-    ds["elevation"] = ("time", np.arange(0, 50, 5))
-
+    # apply georeferencing
     ds = get_x_y_z(ds)
 
-    # Check to see if the origin contains all 0s
-    origin = ds.isel(range=0, time=0)
+    # Check to see if the mean of the first range bins are 0
+    # we have ranges at center of bin
+    origin = ds.isel(range=0).reset_coords().mean("time")
     assert_almost_equal(origin.x, 0)
     assert_almost_equal(origin.y, 0)
-    assert_almost_equal(origin.z, 0)
+    # center of first bin has already some added elevation
+    assert_almost_equal(origin.z, ds.altitude + 0.87276752)
 
     # Make sure that at 180 degrees, x is (close to) 0
-    np.testing.assert_almost_equal(
-        ds.isel(range=0, time=np.where(ds.azimuth == 180)[0]).x, 0
-    )
+    # select the two beams around 180deg and calculate mean
+    sel = ds.where((ds.azimuth >= 179) & (ds.azimuth <= 181), drop=True)
+    sel = sel.reset_coords().isel(range=0).mean("time")
+    np.testing.assert_almost_equal(sel.x, 0)
+    np.testing.assert_approx_equal(sel.y, -50, significant=3)
 
     # Make sure that at 270 degrees, y is (close to) 0
-    np.testing.assert_almost_equal(
-        ds.isel(range=0, time=np.where(ds.azimuth == 270)[0]).y, 0
-    )
+    # select the two beams around 270deg and calculate mean
+    sel = ds.where((ds.azimuth >= 269) & (ds.azimuth <= 271), drop=True)
+    sel = sel.reset_coords().isel(range=0).mean("time")
+    np.testing.assert_almost_equal(sel.y, 0)
+    np.testing.assert_approx_equal(sel.x, -50, significant=3)
+
+    # Make sure spatial_ref has been added with the correct values
+    assert ds.spatial_ref == 0
+    crs = {
+        "semi_major_axis": 6378137.0,
+        "semi_minor_axis": 6356752.314245179,
+        "inverse_flattening": 298.257223563,
+        "reference_ellipsoid_name": "WGS 84",
+        "longitude_of_prime_meridian": 0.0,
+        "prime_meridian_name": "Greenwich",
+        "geographic_crs_name": "unknown",
+        "horizontal_datum_name": "World Geodetic System 1984",
+        "projected_crs_name": "unknown",
+        "grid_mapping_name": "azimuthal_equidistant",
+        "latitude_of_projection_origin": 46.172541,
+        "longitude_of_projection_origin": 8.7877271,
+        "false_easting": 0.0,
+        "false_northing": 0.0,
+    }
+    for key, value in crs.items():
+        if type(value) == float:
+            assert ds.spatial_ref.attrs[key] == pytest.approx(value)
+        else:
+            assert ds.spatial_ref.attrs[key] == value

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+# Copyright (c) 2022-2023, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
 import datatree as dt
 import numpy as np
 from numpy.testing import assert_almost_equal
@@ -8,23 +12,26 @@ import xradar as xd
 def test_georeference_dataarray():
     radar = xd.model.create_sweep_dataset()
     radar["sample_field"] = radar.azimuth + radar.range
+
     geo = radar.sample_field.xradar.georeference()
+    assert_almost_equal(geo.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407]))
     assert_almost_equal(
-        geo.x.values[:3, 0], np.array([0.43626028, 1.30864794, 2.18063697])
+        geo.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
     )
     assert_almost_equal(
-        geo.y.values[:3, 0], np.array([49.99047607, 49.97524848, 49.94479795])
+        geo.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
     )
 
 
 def test_georeference_dataset():
     radar = xd.model.create_sweep_dataset()
     geo = radar.xradar.georeference()
+    assert_almost_equal(geo.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407]))
     assert_almost_equal(
-        geo.x.values[:3, 0], np.array([0.43626028, 1.30864794, 2.18063697])
+        geo.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
     )
     assert_almost_equal(
-        geo.y.values[:3, 0], np.array([49.99047607, 49.97524848, 49.94479795])
+        geo.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
     )
 
 
@@ -33,8 +40,11 @@ def test_georeference_datatree():
     tree = dt.DataTree.from_dict({"sweep_0": radar})
     geo = tree.xradar.georeference()["sweep_0"]
     assert_almost_equal(
-        geo["x"].values[:3, 0], np.array([0.43626028, 1.30864794, 2.18063697])
+        geo["x"].values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407])
     )
     assert_almost_equal(
-        geo["y"].values[:3, 0], np.array([49.99047607, 49.97524848, 49.94479795])
+        geo["y"].values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+    )
+    assert_almost_equal(
+        geo["z"].values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
     )

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2022, openradar developers.
+# Copyright (c) 2022-2023, openradar developers.
 # Distributed under the MIT License. See LICENSE for more info.
 
 """Tests for `xradar` model package."""
@@ -26,6 +26,9 @@ def test_create_sweep_dataset():
     assert ds.range[-1] == 99950
     assert ds.time[0].values == np.datetime64("2022-08-27T10:00:00.000000000")
     assert ds.time[-1].values == np.datetime64("2022-08-27T10:01:29.750000000")
+    assert ds.altitude == 375
+    assert ds.longitude == 8.7877271
+    assert ds.latitude == 46.172541
 
     # provide azimuth- and time-resolution and fixed elevation
     ds = model.create_sweep_dataset(azimuth=1.0, elevation=5.0, time=1)

--- a/tox.ini
+++ b/tox.ini
@@ -17,4 +17,3 @@ deps =
 commands =
     python -m pip install -U pip
     python -m pytest --basetemp={envtmpdir}
-

--- a/xradar/accessors.py
+++ b/xradar/accessors.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2022, openradar developers.
+# Copyright (c) 2022-2023, openradar developers.
 # Distributed under the MIT License. See LICENSE for more info.
 
 """
@@ -29,7 +29,7 @@ import sys
 import datatree as dt
 import xarray as xr
 
-from .georeference import get_x_y_z, get_x_y_z_tree
+from .georeference import add_crs, add_crs_tree, get_crs, get_x_y_z, get_x_y_z_tree
 
 
 def accessor_constructor(self, xarray_obj):
@@ -76,13 +76,14 @@ class XradarDataArrayAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to xarray.DataArray objects."""
 
     def georeference(
-        self, earth_radius=6371000, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None
     ) -> xr.DataArray:
         """
         Parameters
         ----------
         earth_radius: float
-            Radius of the earth (default is 6371000 m).
+            Radius of the earth. Defaults to a latitude-dependent radius derived from
+            WGS84 ellipsoid.
         effective_radius_fraction: float
             Fraction of earth to use for the effective radius (default is 4/3).
         Returns
@@ -91,11 +92,33 @@ class XradarDataArrayAccessor(XradarAccessor):
             Dataset including x, y, and z as coordinates.
         """
         radar = self.xarray_obj
+
         return radar.pipe(
             get_x_y_z,
             earth_radius=earth_radius,
             effective_radius_fraction=effective_radius_fraction,
         )
+
+    def add_crs(self) -> xr.DataArray:
+        """Add 'spatial_ref' coordinate derived from pyproj.CRS
+
+        Returns
+        -------
+        da : xr.DataArray
+            DataArray including spatial_ref coordinate.
+        """
+        ds = self.xarray_obj
+        return ds.pipe(add_crs)
+
+    def get_crs(self):
+        """Retrieve pyproj.CRS from 'spatial_ref' coordinate
+
+        Returns
+        -------
+        proj_crs : :py:class:`pyproj.CRS`
+        """
+        radar = self.xarray_obj
+        return radar.pipe(get_crs)
 
 
 @xr.register_dataset_accessor("xradar")
@@ -103,14 +126,15 @@ class XradarDataSetAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to xarray.DataArray objects."""
 
     def georeference(
-        self, earth_radius=6371000, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None
     ) -> xr.Dataset:
         """
         Add georeference information to an xarray dataset
         Parameters
         ----------
         earth_radius: float
-            Radius of the earth (default is 6371000 m).
+            Radius of the earth. Defaults to a latitude-dependent radius derived from
+            WGS84 ellipsoid.
         effective_radius_fraction: float
             Fraction of earth to use for the effective radius (default is 4/3).
         Returns
@@ -125,28 +149,63 @@ class XradarDataSetAccessor(XradarAccessor):
             effective_radius_fraction=effective_radius_fraction,
         )
 
+    def add_crs(self) -> xr.DataSet:
+        """Add 'spatial_ref' coordinate derived from pyproj.CRS
+
+        Returns
+        -------
+        ds : xr.Dataset
+            Dataset including spatial_ref coordinate.
+        """
+        radar = self.xarray_obj
+        return radar.pipe(add_crs)
+
+    def get_crs(self):
+        """Retrieve pyproj.CRS from 'spatial_ref' coordinate
+
+        Returns
+        -------
+        proj_crs : :py:class:`pyproj.CRS`
+        """
+        radar = self.xarray_obj
+        return radar.pipe(get_crs)
+
 
 @dt.register_datatree_accessor("xradar")
 class XradarDataTreeAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to datatree.DataTree objects."""
 
     def georeference(
-        self, earth_radius=6371000, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None
     ) -> dt.DataTree:
         """
         Add georeference information to an xradar datatree object
         Parameters
         ----------
         earth_radius: float
-            Radius of the earth (default is 6371000 m).
+            Radius of the earth. Defaults to a latitude-dependent radius derived from
+            WGS84 ellipsoid.
         effective_radius_fraction: float
             Fraction of earth to use for the effective radius (default is 4/3).
         Returns
         -------
         da = dt.Datatree
-            Daatree including x, y, and z as coordinates.
+            Datatree including x, y, and z as coordinates.
         """
         radar = self.xarray_obj
         return radar.pipe(
-            get_x_y_z_tree, earth_radius=6371000, effective_radius_fraction=None
+            get_x_y_z_tree,
+            earth_radius=earth_radius,
+            effective_radius_fraction=effective_radius_fraction,
         )
+
+    def add_crs(self) -> dt.DataTree:
+        """Add 'spatial_ref' coordinate derived from pyproj.CRS
+
+        Returns
+        -------
+        da : dt.DataTree
+            Datatree including spatial_ref coordinate.
+        """
+        ds = self.xarray_obj
+        return ds.pipe(add_crs_tree)

--- a/xradar/georeference/__init__.py
+++ b/xradar/georeference/__init__.py
@@ -10,8 +10,10 @@ XRadar Georeferencing
     :maxdepth: 4
 
 .. automodule:: xradar.georeference.transforms
+.. automodule:: xradar.georeference.projection
 
 """
 from .transforms import *  # noqa
+from .projection import *  # noqa
 
 __all__ = [s for s in dir() if not s.startswith("_")]

--- a/xradar/georeference/projection.py
+++ b/xradar/georeference/projection.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python
+# Copyright (c) 2023, openradar developers.
+# Distributed under the MIT License. See LICENSE for more info.
+
+"""
+Projection
+^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   {}
+"""
+
+__all__ = ["get_earth_radius", "add_crs", "add_crs_tree", "get_crs"]
+
+__doc__ = __doc__.format("\n   ".join(__all__))
+
+import numpy as np
+import pyproj
+from xarray import Variable
+
+
+def get_earth_radius(crs, latitude):
+    """Return earth radius (in m) for a given Spheroid model (crs) at a given latitude.
+
+    .. math::
+
+        R^2 = \\frac{a^4 \\cos(f)^2 + b^4 \\sin(f)^2}
+        {a^2 \\cos(f)^2 + b^2 \\sin(f)^2}
+
+    Parameters
+    ----------
+    crs : :py:class:`pyproj.CRS`
+        spatial reference object
+    latitude : float
+        geodetic latitude in degrees
+
+    Returns
+    -------
+    radius : float
+        earth radius in meter
+    """
+    geod = crs.get_geod()
+    latitude = np.radians(latitude)
+    radius = np.sqrt(
+        (
+            np.power(geod.a, 4) * np.power(np.cos(latitude), 2)
+            + np.power(geod.b, 4) * np.power(np.sin(latitude), 2)
+        )
+        / (
+            np.power(geod.a, 2) * np.power(np.cos(latitude), 2)
+            + np.power(geod.b, 2) * np.power(np.sin(latitude), 2)
+        )
+    )
+    return radius
+
+
+def get_crs(ds, datum="WGS84"):
+    """Return pyproj.CRS from 'spatial_ref' coordinate
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+    datum : str
+        datum string, defaults to 'WGS84'
+
+    Returns
+    -------
+    proj_crs : :py:class:`pyproj.CRS`
+    """
+    if "spatial_ref" in ds:
+        proj_crs = pyproj.CRS.from_cf(ds["spatial_ref"].attrs)
+    else:
+        proj_crs = pyproj.CRS(
+            proj="aeqd",
+            datum=datum,
+            lon_0=ds.longitude.values,
+            lat_0=ds.latitude.values,
+        )
+    return proj_crs
+
+
+def add_crs(ds, crs=None, datum="WGS84"):
+    """Add 'spatial_ref' coordinate derived from pyproj.CRS
+
+    Parameters
+    ----------
+    ds : xr.Dataset
+    crs : :py:class:`pyproj.CRS`
+        pyproj.CRS to be added, defaults to AEQD (with given datum)
+    datum : str
+        datum string, defaults to 'WGS84'
+
+    Returns
+    -------
+    ds : xr.Dataset
+        Dataset including spatial_ref coordinate.
+    """
+    spatial_ref = Variable((), 0)
+    if crs is None:
+        proj_crs = get_crs(ds, datum=datum)
+    else:
+        proj_crs = crs
+    spatial_ref.attrs.update(proj_crs.to_cf())
+    ds = ds.assign_coords(spatial_ref=spatial_ref)
+    return ds
+
+
+def add_crs_tree(radar, datum="WGS84"):
+    """Add 'spatial_ref' coordinate derived from pyproj.CRS
+
+    Parameters
+    ----------
+    radar : xr.Dataset
+    crs : :py:class:`pyproj.CRS`
+        pyproj.CRS to be added, defaults to AEQD (with given datum)
+    datum : str
+        datum string, defaults to 'WGS84'
+
+    Returns
+    -------
+    radar : dt.DataTree
+        Datatree with sweep datasets including spatial_ref coordinate.
+    """
+    for key in list(radar.children):
+        if "sweep" in key:
+            radar[key].ds = add_crs(radar[key].to_dataset(), datum=datum)
+    return radar

--- a/xradar/georeference/transforms.py
+++ b/xradar/georeference/transforms.py
@@ -1,20 +1,43 @@
 #!/usr/bin/env python
-# Copyright (c) 2022, openradar developers.
+# Copyright (c) 2022-2023, openradar developers.
 # Distributed under the MIT License. See LICENSE for more info.
+
+"""
+Transformations
+^^^^^^^^^^^^^^^
+
+.. autosummary::
+   :nosignatures:
+   :toctree: generated/
+
+   {}
+"""
+
+__all__ = ["antenna_to_cartesian", "get_x_y_z", "get_x_y_z_tree"]
+
+__doc__ = __doc__.format("\n   ".join(__all__))
+
 
 import numpy as np
 import xarray as xr
 
+from .projection import add_crs, get_crs, get_earth_radius
+
 
 def antenna_to_cartesian(
-    ranges, azimuths, elevations, earth_radius=6371000, effective_radius_fraction=None
+    ranges,
+    azimuths,
+    elevations,
+    earth_radius=6371000,
+    effective_radius_fraction=None,
+    site_altitude=0,
 ):
-    """
-    Return Cartesian coordinates from antenna coordinates.
+    """Return Cartesian coordinates from antenna coordinates.
+
     Parameters
     ----------
     ranges : array
-        Distances to the center of the radar gates (bins) in kilometers.
+        Distances to the center of the radar gates (bins) in meters.
     azimuths : array
         Azimuth angle of the radar in degrees.
     elevations : array
@@ -23,24 +46,32 @@ def antenna_to_cartesian(
         Radius of the earth (default is 6371000 m).
     effective_radius_fraction: float
         Fraction of earth to use for the effective radius (default is 4/3).
+    site_altitude: float
+        Altitude amsl of radar site
+
     Returns
     -------
     x, y, z : array
         Cartesian coordinates in meters from the radar.
+
     Notes
     -----
     The calculation for Cartesian coordinate is adapted from equations
     2.28(b) and 2.28(c) of Doviak and Zrnic [1]_ assuming a
     standard atmosphere (4/3 Earth's radius model).
+
     .. math::
+
         z = \\sqrt{r^2+R^2+2*r*R*sin(\\theta_e)} - R
         s = R * arcsin(\\frac{r*cos(\\theta_e)}{R+z})
         x = s * sin(\\theta_a)
         y = s * cos(\\theta_a)
+
     Where r is the distance from the radar to the center of the gate,
     :math:`\\theta_a` is the azimuth angle, :math:`\\theta_e` is the
     elevation angle, s is the arc length, and R is the effective radius
     of the earth, taken to be 4/3 the mean radius of earth (6371 km).
+
     References
     ----------
     .. [1] Doviak and Zrnic, Doppler Radar and Weather Observations, Second
@@ -54,47 +85,62 @@ def antenna_to_cartesian(
     R = earth_radius * effective_radius_fraction  # effective radius of earth in meters.
     r = ranges  # distances to gates in meters.
 
-    z = (2.0 * np.sin(theta_e) * r * R + r**2 + R**2) ** 0.5 - R
+    # take site altitude into account
+    sr = R + site_altitude
+
+    z = (2.0 * np.sin(theta_e) * r * sr + r**2 + sr**2) ** 0.5 - R
     s = R * np.arcsin(r * np.cos(theta_e) / (R + z))  # arc length in m.
     x = np.sin(theta_a) * s
     y = np.cos(theta_a) * s
     return x, y, z
 
 
-def get_x_y_z(ds, earth_radius=6371000, effective_radius_fraction=None):
+def get_x_y_z(ds, earth_radius=None, effective_radius_fraction=None):
     """
     Return Cartesian coordinates from antenna coordinates.
+
     Parameters
     ----------
     ds: xarray.Dataset
         Xarray dataset containing range, azimuth, and elevation
     earth_radius: float
-        Radius of the earth (default is 6371000 m).
+        Radius of the earth. Defaults to a latitude-dependent radius derived from
+        WGS84 ellipsoid.
     effective_radius_fraction: float
         Fraction of earth to use for the effective radius (default is 4/3).
+
     Returns
     -------
     ds : xarray.Dataset
         Dataset including x, y, and z as coordinates.
+
     Notes
     -----
     The calculation for Cartesian coordinate is adapted from equations
     2.28(b) and 2.28(c) of Doviak and Zrnic [1]_ assuming a
     standard atmosphere (4/3 Earth's radius model).
+
     .. math::
+
         z = \\sqrt{r^2+R^2+2*r*R*sin(\\theta_e)} - R
         s = R * arcsin(\\frac{r*cos(\\theta_e)}{R+z})
         x = s * sin(\\theta_a)
         y = s * cos(\\theta_a)
+
     Where r is the distance from the radar to the center of the gate,
     :math:`\\theta_a` is the azimuth angle, :math:`\\theta_e` is the
     elevation angle, s is the arc length, and R is the effective radius
     of the earth, taken to be 4/3 the mean radius of earth (6371 km).
+
     References
     ----------
     .. [1] Doviak and Zrnic, Doppler Radar and Weather Observations, Second
         Edition, 1993, p. 21.
     """
+    if earth_radius is None:
+        crs = get_crs(ds)
+        earth_radius = get_earth_radius(crs, ds.latitude.values)
+        ds = ds.pipe(add_crs, crs)
 
     # Calculate x, y, and z from the dataset
     ds["x"], ds["y"], ds["z"] = antenna_to_cartesian(
@@ -103,9 +149,11 @@ def get_x_y_z(ds, earth_radius=6371000, effective_radius_fraction=None):
         ds.elevation,
         earth_radius=earth_radius,
         effective_radius_fraction=effective_radius_fraction,
+        site_altitude=ds.altitude.values,
     )
 
     # Set the attributes for the dataset
+    # todo: possible utilize crs.cs_to_cf() for x/y
     ds.x.attrs = {"standard_name": "east_west_distance_from_radar", "units": "meters"}
 
     ds.y.attrs = {"standard_name": "north_south_distance_from_radar", "units": "meters"}
@@ -119,17 +167,20 @@ def get_x_y_z(ds, earth_radius=6371000, effective_radius_fraction=None):
     return ds
 
 
-def get_x_y_z_tree(radar, earth_radius=6371000, effective_radius_fraction=None):
+def get_x_y_z_tree(radar, earth_radius=None, effective_radius_fraction=None):
     """
     Applies the georeferencing to a xradar datatree
+
     Parameters
     ----------
     radar: dt.DataTree
         Xradar datatree object with radar information.
     earth_radius: float
-        Radius of the earth (default is 6371000 m).
+        Radius of the earth. Defaults to a latitude-dependent radius derived from
+        WGS84 ellipsoid.
     effective_radius_fraction: float
         Fraction of earth to use for the effective radius (default is 4/3).
+
     Returns
     -------
     radar: dt.DataTree

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-# Copyright (c) 2022, openradar developers.
+# Copyright (c) 2022-2023, openradar developers.
 # Distributed under the MIT License. See LICENSE for more info.
 
 """
@@ -84,7 +84,7 @@ required_global_attrs = dict(
 )
 
 
-# optional global attributes (root-group)
+#: optional global attributes (root-group)
 optional_root_attrs = dict(
     [
         ("site_name", "name of site where data were gathered"),
@@ -952,12 +952,21 @@ def create_sweep_dataset(**kwargs):
     time = get_time_dataarray(time, nrays, date_str)
     rng = get_range_dataarray(rng, nbins)
 
+    # get site coordinates, Locarno Monti, MeteoSwiss
+    # trivia: the place where xradar was born in August 2022
+    altitude = 375
+    latitude = 46.172541
+    longitude = 8.7877271
+
     ds = Dataset(
         coords=dict(
             time=time,
             range=rng,
             azimuth=azimuth,
             elevation=elevation,
+            longitude=([], longitude, get_longitude_attrs()),
+            latitude=([], latitude, get_latitude_attrs()),
+            altitude=([], altitude, get_altitude_attrs()),
         )
     )
 


### PR DESCRIPTION
This adds `spatial_ref` to the datasets when georeferencing. That way users can easily wrap this into cartopy and use this for georeferenced plotting.

- tests added/adapted
- added example to plot-ppi.ipynb notebook
- takes site coordinates into account (altitude) for georeferencing
- site coordinates are in default model Dataset (Locarno Monti, MeteoSvizzera coords, birthplace of xradar)