### PR TITLE
ENH: make copy before overwriting, add compression in to_odim

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,7 @@
 ## Development Version
 
 * FIX: check for dim0 if not given, only swap_dims if needed ({issue}`92`), ({pull}`94`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX+ENH: need array copy before overwriting and make compression available in to_odim ({pull}`95`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 
 ## 0.1.0 (2023-02-23)
 

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -625,10 +625,15 @@ def test_open_iris1_dataset(iris1_file):
     assert ds.sweep_number == 0
 
 
-def test_odim_roundtrip(odim_file2):
+@pytest.mark.parametrize(
+    "compression, compression_opts", [("gzip", 0), ("gzip", 6), ("gzip", 9)]
+)
+def test_odim_roundtrip(odim_file2, compression, compression_opts):
     dtree = open_odim_datatree(odim_file2)
-    outfile = "odim_out.h5"
-    xradar.io.to_odim(dtree, outfile)
+    outfile = tempfile.NamedTemporaryFile(mode="w+b").name
+    xradar.io.to_odim(
+        dtree, outfile, compression=compression, compression_opts=compression_opts
+    )
     dtree2 = open_odim_datatree(outfile, reindex_angle=False)
     for d0, d1 in zip(dtree.groups, dtree2.groups):
         print(d0, d1)

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -59,7 +59,7 @@ def _write_odim(source, destination):
             destination.attrs[key] = value
 
 
-def _write_odim_dataspace(source, destination):
+def _write_odim_dataspace(source, destination, compression, compression_opts):
     """Write ODIM_H5 Dataspaces.
 
     Parameters
@@ -68,6 +68,10 @@ def _write_odim_dataspace(source, destination):
         Moments to write
     destination : handle
         h5py-group handle
+    compression : str
+        Compression filter name
+    compression_opts : compression strategy
+        options as needed by above filter
     """
     # todo: check bottom-up/top-down rhi
     dim0 = "elevation" if source.sweep_mode == "rhi" else "azimuth"
@@ -114,8 +118,8 @@ def _write_odim_dataspace(source, destination):
         ds = h5_data.create_dataset(
             "data",
             data=val,
-            compression="gzip",
-            compression_opts=6,
+            compression=compression,
+            compression_opts=compression_opts,
             fillvalue=_fillvalue,
             dtype=dtype,
         )
@@ -132,7 +136,7 @@ def _write_odim_dataspace(source, destination):
             ds.attrs.create("IMAGE_VERSION", version, dtype=H5T_C_S1_VER)
 
 
-def to_odim(dtree, filename):
+def to_odim(dtree, filename, compression="gzip", compression_opts=6):
     """Save DataTree to ODIM_H5/V2_2 compliant file.
 
     Parameters
@@ -140,6 +144,14 @@ def to_odim(dtree, filename):
     dtree : datatree.DataTree
     filename : str
         output filename
+
+    Keyword Arguments
+    -----------------
+    compression : str
+        Compression filter name, defaults to "gzip".
+    compression_opts : compression strategy
+        options as needed by above filter, defaults to 6
+
     """
     root = dtree["/"]
 
@@ -257,6 +269,6 @@ def to_odim(dtree, filename):
         _write_odim(ds_how, h5_ds_how)
 
         # write moments
-        _write_odim_dataspace(ds, h5_dataset)
+        _write_odim_dataspace(ds, h5_dataset, compression, compression_opts)
 
     h5.close()

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -113,8 +113,6 @@ def _write_odim_dataspace(source, destination, compression, compression_opts):
         val[np.isnan(val)] = fillval
         if np.issubdtype(dtype, np.integer):
             val = np.rint(val).astype(dtype)
-        # todo: compression is chosen totally arbitrary here
-        #  maybe parameterizing it?
         ds = h5_data.create_dataset(
             "data",
             data=val,

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -105,8 +105,8 @@ def _write_odim_dataspace(source, destination):
         val = value.sortby(dim0).values
         fillval = _fillvalue * scale_factor
         fillval += add_offset
-        val[np.isnan(val)] = fillval
         val = (val - add_offset) / scale_factor
+        val[np.isnan(val)] = fillval
         if np.issubdtype(dtype, np.integer):
             val = np.rint(val).astype(dtype)
         # todo: compression is chosen totally arbitrary here


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [ ] Closes #xxxx
- [x] Tests added
- [x] Changes are documented in `history.md`

This fixes an issue when writing `to_odim` if the underlying data array's write flag wasn't set. It also adds the capability to add `compression`/`compression_opts` kwargs in the call to `to_odim`.

The latter makes it very easy and convenient to use the [zoo of compressors](https://portal.hdfgroup.org/display/support/Registered+Filter+Plugins) available to `hdf5`. Please refer to http://www.silx.org/doc/hdf5plugin/latest/index.html for usage examples.
