### PR TITLE
ENH: switch to add recommended metadata

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development Version
 
+* ENH: switch to add optional how attributes in ODIM format writer ({pull}`97`) by [@egouden](https://github.com/egouden)
 * FIX: add keyword argument for mandatory source attribute in ODIM format writer ({pull}`96`) by [@egouden](https://github.com/egouden)
 * FIX: check for dim0 if not given, only swap_dims if needed ({issue}`92`), ({pull}`94`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * FIX+ENH: need array copy before overwriting and make compression available in to_odim ({pull}`95`) by [@kmuehlbauer](https://github.com/kmuehlbauer)

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -641,8 +641,50 @@ def test_odim_roundtrip(odim_file2, compression, compression_opts):
     )
     dtree2 = open_odim_datatree(outfile, reindex_angle=False)
     for d0, d1 in zip(dtree.groups, dtree2.groups):
-        print(d0, d1)
         xr.testing.assert_equal(dtree[d0].ds, dtree2[d1].ds)
+
+
+def test_odim_optional_how(odim_file2):
+    dtree = open_odim_datatree(odim_file2)
+    outfile = tempfile.NamedTemporaryFile(mode="w+b").name
+    xradar.io.to_odim(
+        dtree,
+        outfile,
+        source="WMO:01104,NOD:norst",
+        optional_how=True,
+    )
+    ds = h5py.File(outfile)
+
+    for i in range(1, 6):
+        ds_how = ds["dataset%s" % (i)]["how"].attrs
+        assert "scan_index" in ds_how
+        assert "scan_count" in ds_how
+        assert "startazA" in ds_how
+        assert "stopazA" in ds_how
+        assert "startazT" in ds_how
+        assert "startazT" in ds_how
+        assert "startelA" in ds_how
+        assert "stopelA" in ds_how
+
+    outfile = tempfile.NamedTemporaryFile(mode="w+b").name
+    xradar.io.to_odim(
+        dtree,
+        outfile,
+        source="WMO:01104,NOD:norst",
+        optional_how=False,
+    )
+    ds = h5py.File(outfile)
+
+    for i in range(1, 6):
+        ds_how = ds["dataset%s" % (i)]["how"].attrs
+        assert "scan_index" not in ds_how
+        assert "scan_count" not in ds_how
+        assert "startazA" not in ds_how
+        assert "stopazA" not in ds_how
+        assert "startazT" not in ds_how
+        assert "startazT" not in ds_how
+        assert "startelA" not in ds_how
+        assert "stopelA" not in ds_how
 
 
 def test_write_odim_source(rainbow_file2):

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -134,7 +134,14 @@ def _write_odim_dataspace(source, destination, compression, compression_opts):
             ds.attrs.create("IMAGE_VERSION", version, dtype=H5T_C_S1_VER)
 
 
-def to_odim(dtree, filename, source=None, compression="gzip", compression_opts=6):
+def to_odim(
+    dtree,
+    filename,
+    source=None,
+    optional_how=False,
+    compression="gzip",
+    compression_opts=6,
+):
     """Save DataTree to ODIM_H5/V2_2 compliant file.
 
     Parameters
@@ -147,6 +154,8 @@ def to_odim(dtree, filename, source=None, compression="gzip", compression_opts=6
     -----------------
     source : str
         mandatory radar identifier (see ODIM documentation)
+    optional_how : boolean
+        True to include optional how attributes, defaults to False
     compression : str
         Compression filter name, defaults to "gzip".
     compression_opts : compression strategy
@@ -265,16 +274,20 @@ def to_odim(dtree, filename, source=None, compression="gzip", compression_opts=6
 
         # ODIM_H5 datasetN numbers are 1-based
         sweep_number = ds.sweep_number + 1
-        ds_how = {
-            "scan_index": sweep_number,
-            "scan_count": len(grps),
-            "startazT": tout - difft,
-            "stopazT": tout + difft,
-            "startazA": azout - diffa,
-            "stopazA": azout + diffa,
-            "startelA": elout - diffe,
-            "stopelA": elout + diffe,
-        }
+
+        ds_how = {}
+        if optional_how:
+            optional = {
+                "scan_index": sweep_number,
+                "scan_count": len(grps),
+                "startazT": tout - difft,
+                "stopazT": tout + difft,
+                "startazA": azout - diffa,
+                "stopazA": azout + diffa,
+                "startelA": elout - diffe,
+                "stopelA": elout + diffe,
+            }
+            ds_how.update(optional)
         _write_odim(ds_how, h5_ds_how)
 
         # write moments


### PR DESCRIPTION
Now by default the function to_odim writes only mandatory metadata. There is a new option to add recommended metadata. See ODIM documentation for more information.

Note that only a few recommended metadata can be written at the moment.