### PR TITLE
FIX: Correct DB_DBTE8/DB_DBZE8 and DB_DBTE16/DB_DBZE16 decoding

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development Version
 * ENH: Add new examples using radar data on AWS s3 bucket ({pull}`102`) by [@aladinor](https://github.com/aladinor)
+* FIX: Correct DB_DBTE8/DB_DBZE8 and DB_DBTE16/DB_DBZE16 decoding for iris-backend ({pull}`110`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 
 ## 0.2.0 (2023-03-24)
 

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -2282,13 +2282,45 @@ SIGMET_DATA_TYPES = OrderedDict(
         # Turbulence (2 byte)
         (70, {"name": "DB_TURB16", "dtype": "uint16", "func": None}),
         # Total Power Enhanced (via H+V or HV) (1 byte)
-        (71, {"name": "DB_DBTE8", "dtype": "uint8", "func": None}),
+        (
+            71,
+            {
+                "name": "DB_DBTE8",
+                "dtype": "uint8",
+                "func": decode_array,
+                "fkw": {"scale": 2.0, "offset": -64.0},
+            },
+        ),
         # Total Power Enhanced (via H+V or HV) (2 byte)
-        (72, {"name": "DB_DBTE16", "dtype": "uint16", "func": None}),
+        (
+            72,
+            {
+                "name": "DB_DBTE16",
+                "dtype": "uint16",
+                "func": decode_array,
+                "fkw": {"scale": 100.0, "offset": -32768.0},
+            },
+        ),
         # Clutter Corrected Reflectivity Enhanced (1 byte)
-        (73, {"name": "DB_DBZE8", "dtype": "uint8", "func": None}),
+        (
+            73,
+            {
+                "name": "DB_DBZE8",
+                "dtype": "uint8",
+                "func": decode_array,
+                "fkw": {"scale": 2.0, "offset": -64.0},
+            },
+        ),
         # Clutter Corrected Reflectivity Enhanced (2 byte)
-        (74, {"name": "DB_DBZE16", "dtype": "uint16", "func": None}),
+        (
+            74,
+            {
+                "name": "DB_DBZE16",
+                "dtype": "uint16",
+                "func": decode_array,
+                "fkw": {"scale": 100.0, "offset": -32768.0},
+            },
+        ),
         # Polarimetric meteo index (1 byte)
         (
             75,


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Changes are documented in `history.md`

Update: 

A bit more context here, we've just stumbled over these types in the wild. I've had a look into the docs/code and they are referenced as:

```
 DB_DBTE8         = 71,  /* Total Power Enhanced (via H+V or HV) (1 byte) */
 DB_DBTE16        = 72,  /* Total Power Enhanced (via H+V or HV) (2 byte) */
 DB_DBZE8         = 73,  /* Clutter Corrected Reflectivity Enhanced (1 byte) */
 DB_DBZE16        = 74,  /* Clutter Corrected Reflectivity Enhanced (2 byte) */
```

I've not added this to the moments mapping (attributes). So for now no attributes will be added. We'll gather more information before adding these attributes.


