### PR TITLE
FIX: Cast boolean string to int in rainbow dictionary

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,7 @@
 ## Development Version
 * ENH: Add new examples using radar data on AWS s3 bucket ({pull}`102`) by [@aladinor](https://github.com/aladinor)
 * FIX: Correct DB_DBTE8/DB_DBZE8 and DB_DBTE16/DB_DBZE16 decoding for iris-backend ({pull}`110`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: Cast boolean string to int in rainbow dictionary ({pull}`113`) by [@egouden](https://github.com/egouden)
 
 ## 0.2.0 (2023-03-24)
 

--- a/xradar/io/backends/rainbow.py
+++ b/xradar/io/backends/rainbow.py
@@ -519,6 +519,8 @@ class RainbowFile(RainbowFileBase):
         if value is None:
             value = self.pargroup.get(name, default)
         if dtype is not None:
+            if dtype == bool:
+                value = int(value)
             value = dtype(value)
         return value
 


### PR DESCRIPTION
Currently a boolean string value of "0" in the Rainbow file (e.g. antdirection) is converted to True instead of False.

bool("0") => True