### PR TITLE
FIX ipol_time not working if last azimuth is first

### DIFF
--- a/xradar/util.py
+++ b/xradar/util.py
@@ -367,7 +367,8 @@ def ipol_time(ds):
     time = ds.time
     if amin > amax:
         time = time.pipe(_ipol_time, 0, amin)
-        time = time.pipe(_ipol_time, amin, -1)
+        if amin != len(time) - 1:
+            time = time.pipe(_ipol_time, amin, -1)
     else:
         time = time.pipe(_ipol_time)
     ds["time"] = time


### PR DESCRIPTION
The function util.ipol_time is not working if the last azimuth is the first timestamp. This causes a zero-length array. You might want to see the change itself for more insight.