### PR TITLE
FIX: time_interpolation

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -5,6 +5,7 @@
 * FIX: Correct DB_DBTE8/DB_DBZE8 and DB_DBTE16/DB_DBZE16 decoding for iris-backend ({pull}`110`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * FIX: Cast boolean string to int in rainbow dictionary ({pull}`113`) by [@egouden](https://github.com/egouden)
 * MNT: switch to mamba-org/setup-micromamba, split CI tests ({issue}`115`), ({pull}`116`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: time interpolation
 
 ## 0.2.0 (2023-03-24)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -149,3 +149,10 @@ def test_ipol_time2(missing, a1gate, rot):
     dsy = dsx.pipe(util.ipol_time, a1gate_idx=a1gate, direction=direction)
     # see if all time values were reconstructed
     xr.testing.assert_equal(ds, dsy)
+
+    # check emit warning
+    if a1gate in [179, 180, 181] and missing and direction == 1:
+        with pytest.warns(
+            UserWarning, match="Rays might miss on beginning and/or end of sweep."
+        ):
+            dsx.pipe(util.ipol_time, direction=direction)

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -439,6 +439,6 @@ class CfRadial1BackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         return ds

--- a/xradar/io/backends/furuno.py
+++ b/xradar/io/backends/furuno.py
@@ -744,7 +744,7 @@ class FurunoBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         # handling first dimension
         dim0 = "elevation" if ds.sweep_mode.load() == "rhi" else "azimuth"

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -487,7 +487,7 @@ class GamicBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         # handling first dimension
         dim0 = "elevation" if ds.sweep_mode.load() == "rhi" else "azimuth"

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -4006,7 +4006,7 @@ class IrisBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         ds.attrs.pop("elevation_lower_limit", None)
         ds.attrs.pop("elevation_upper_limit", None)

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -748,7 +748,7 @@ class OdimBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         # handling first dimension
         dim0 = "elevation" if ds.sweep_mode.load() == "rhi" else "azimuth"

--- a/xradar/io/backends/rainbow.py
+++ b/xradar/io/backends/rainbow.py
@@ -838,7 +838,7 @@ class RainbowBackendEntrypoint(BackendEntrypoint):
         if decode_coords and reindex_angle is not False:
             ds = ds.pipe(util.remove_duplicate_rays)
             ds = ds.pipe(util.reindex_angle, **reindex_angle)
-            ds = ds.pipe(util.ipol_time)
+            ds = ds.pipe(util.ipol_time, **reindex_angle)
 
         # handling first dimension
         dim0 = "elevation" if ds.sweep_mode.load() == "rhi" else "azimuth"

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -887,6 +887,8 @@ def create_sweep_dataset(**kwargs):
         range resolution or array with range values.
     azimuth : float or :class:`numpy:numpy.ndarray`
         azimuth resolution or array with azimuth values.
+    direction : int
+        1 - CW/UP, -1 CCW/DOWN
     a1gate : int
         First measured ray. Defaults to 0. Only used for PPI.
     elevation : float or :class:`numpy:numpy.ndarray`
@@ -937,10 +939,11 @@ def create_sweep_dataset(**kwargs):
     time = kwargs.pop("time", 0.25)
     date_str = kwargs.pop("date_str", "2022-08-27T10:00:00")
     rng = kwargs.pop("rng", 100)
+    direction = kwargs.pop("direction", 1)
 
     # calculate according to PPI/RHI
     if sweep == "PPI":
-        azimuth = get_azimuth_dataarray(azimuth, nrays=None, a1gate=a1gate)
+        azimuth = get_azimuth_dataarray(azimuth, nrays=None, a1gate=a1gate)[::direction]
         nrays = azimuth.shape[0]
         elevation = get_elevation_dataarray(elevation, nrays=nrays)
     else:


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Tests added
- [x] Changes are documented in `history.md`

As reported by @egouden in #114 there are issues with time interpolation in some corner cases. While adding a test for this I've found there are more things involved which need changing. This PR addresses (hopefully) all of this.

- only interpolate of NaT present
- handle NaT correctly (-9223372036854775808)
- handle a1gate properly (roll data to first measured ray)
- derive interpolation angles using diff
- handle wrap around angles for PPI
- fix spurious digits introduced by floating point interpolation

Supersedes #114
