### PR TITLE
FIX: always read nodata and undetect attributes from ODIM file

### DIFF
--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -353,8 +353,8 @@ class _OdimH5NetCDFMetadata:
         if not (gain == 1.0 and offset == 0.0):
             attrs["scale_factor"] = gain
             attrs["add_offset"] = offset
-            attrs["_FillValue"] = what.get("nodata", None)
-            attrs["_Undetect"] = what.get("undetect", 0.0)
+        attrs["_FillValue"] = what.get("nodata", None)
+        attrs["_Undetect"] = what.get("undetect", 0.0)
         # if no quantity is given, use the group-name
         attrs["quantity"] = _maybe_decode(
             what.get("quantity", self._group.split("/")[-1])


### PR DESCRIPTION
The current behavior is to not read ODIM _undetect_ and _nodata_ attributes if the values are not transformed (i.e. the attribute _gain_ is 1 and the attribute _offset_ is 0). This can lead to a loss of information. I think these attributes should always be read.