### PR TITLE
use `crs_wkt` instead of deprecated `spatial_ref`

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,7 @@
 ## development version
 
 * FIX: use datastore._group instead of variable["sweep_number"] ({issue}`121`) by [@aladinor](https://github.com/aladinor) , {pull}`123`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* MIN: use "crs_wkt" instead of deprecated "spatial_ref" when adding CRS ({pull}`127`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 
 ## 0.3.0 (2023-07-11)
 * ENH: Add new examples using radar data on AWS s3 bucket ({pull}`102`) by [@aladinor](https://github.com/aladinor)

--- a/tests/georeference/test_projection.py
+++ b/tests/georeference/test_projection.py
@@ -60,7 +60,7 @@ def test_write_crs():
     ds = add_crs(ds)
 
     # Make sure spatial_ref has been added with the correct values
-    assert ds.spatial_ref == 0
+    assert ds.crs_wkt == 0
     crs = {
         "semi_major_axis": 6378137.0,
         "semi_minor_axis": 6356752.314245179,
@@ -79,6 +79,6 @@ def test_write_crs():
     }
     for key, value in crs.items():
         if isinstance(value, float):
-            assert ds.spatial_ref.attrs[key] == pytest.approx(value)
+            assert ds.crs_wkt.attrs[key] == pytest.approx(value)
         else:
-            assert ds.spatial_ref.attrs[key] == value
+            assert ds.crs_wkt.attrs[key] == value

--- a/tests/georeference/test_transforms.py
+++ b/tests/georeference/test_transforms.py
@@ -60,7 +60,7 @@ def test_get_x_y_z():
     np.testing.assert_approx_equal(sel.x, -50, significant=3)
 
     # Make sure spatial_ref has been added with the correct values
-    assert ds.spatial_ref == 0
+    assert ds.crs_wkt == 0
     crs = {
         "semi_major_axis": 6378137.0,
         "semi_minor_axis": 6356752.314245179,
@@ -79,6 +79,6 @@ def test_get_x_y_z():
     }
     for key, value in crs.items():
         if isinstance(value, float):
-            assert ds.spatial_ref.attrs[key] == pytest.approx(value)
+            assert ds.crs_wkt.attrs[key] == pytest.approx(value)
         else:
-            assert ds.spatial_ref.attrs[key] == value
+            assert ds.crs_wkt.attrs[key] == value

--- a/xradar/georeference/projection.py
+++ b/xradar/georeference/projection.py
@@ -58,7 +58,7 @@ def get_earth_radius(crs, latitude):
 
 
 def get_crs(ds, datum="WGS84"):
-    """Return :py:class:`pyproj.crs.CoordinateSystem` from ``spatial_ref`` coordinate.
+    """Return :py:class:`pyproj.crs.CoordinateSystem` from ``crs_wkt`` or ``spatial_ref`` coordinate.
 
     Parameters
     ----------
@@ -70,8 +70,15 @@ def get_crs(ds, datum="WGS84"):
     -------
     proj_crs : :py:class:`~pyproj.crs.CoordinateSystem`
     """
-    if "spatial_ref" in ds:
-        proj_crs = pyproj.CRS.from_cf(ds["spatial_ref"].attrs)
+    crs_wkt = (
+        ds["crs_wkt"]
+        if "crs_wkt" in ds
+        else ds["spatial_ref"]
+        if "spatial_ref" in ds
+        else False
+    )
+    if crs_wkt:
+        proj_crs = pyproj.CRS.from_cf(crs_wkt.attrs)
     else:
         proj_crs = pyproj.CRS(
             proj="aeqd",
@@ -83,46 +90,46 @@ def get_crs(ds, datum="WGS84"):
 
 
 def add_crs(ds, crs=None, datum="WGS84"):
-    """Add ``spatial_ref`` coordinate derived from :py:class:`pyproj.crs.CoordinateSystem`.
+    """Add ``crs_wkt`` coordinate derived from :py:class:`pyproj.crs.CoordinateSystem`.
 
     Parameters
     ----------
     ds : xarray.Dataset
     crs : :py:class:`~pyproj.crs.CoordinateSystem`
-        ``spatial_ref`` to be added, defaults to ``AEQD`` (with given datum)
+        ``crs_wkt`` to be added, defaults to ``AEQD`` (with given datum)
     datum : str
         datum string, defaults to 'WGS84'
 
     Returns
     -------
     ds : xarray.Dataset
-        Dataset including ``spatial_ref`` coordinate.
+        Dataset including ``crs_wkt`` coordinate.
     """
-    spatial_ref = Variable((), 0)
+    crs_wkt = Variable((), 0)
     if crs is None:
         proj_crs = get_crs(ds, datum=datum)
     else:
         proj_crs = crs
-    spatial_ref.attrs.update(proj_crs.to_cf())
-    ds = ds.assign_coords(spatial_ref=spatial_ref)
+    crs_wkt.attrs.update(proj_crs.to_cf())
+    ds = ds.assign_coords(crs_wkt=crs_wkt)
     return ds
 
 
 def add_crs_tree(radar, datum="WGS84"):
-    """Add ``spatial_ref`` coordinate derived from :py:class:`pyproj.crs.CoordinateSystem`.
+    """Add ``crs_wkt`` coordinate derived from :py:class:`pyproj.crs.CoordinateSystem`.
 
     Parameters
     ----------
     radar : xarray.Dataset
     crs : :py:class:`~pyproj.crs.CoordinateSystem`
-        ``spatial_ref`` to be added, defaults to ``AEQD`` (with given datum)
+        ``crs_wkt`` to be added, defaults to ``AEQD`` (with given datum)
     datum : str
         datum string, defaults to 'WGS84'
 
     Returns
     -------
     radar : datatree.DataTree
-        Datatree with sweep datasets including ``spatial_ref`` coordinate.
+        Datatree with sweep datasets including ``crs_wkt`` coordinate.
     """
     for key in list(radar.children):
         if "sweep" in key:


### PR DESCRIPTION
This forces writing of `crs_wkt` instead of deprecated `spatial_ref`. On reading `crs_wkt` takes precedence over `spatial_ref` (for backwards compatibility).

<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Tests fixed
- [x] Changes are documented in `history.md`
