### PR TITLE
FIX: prevent integer overflow when calculating azimuth in FURUNO scn files

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,7 @@
 ## Development version (unreleased)
 
 * FIX: Add history to cfradial1 output, and fix minor error in CfRadial1_Export.ipynb notebook({pull}`132`) by [@syedhamidali](https://github.com/syedhamidali)
+* FIX: prevent integer overflow when calculating azimuth in FURUNO scn files ({issue}`137`) by [@giacant](https://github.com/giacant) , ({pull}`138`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 
 ## 0.4.0 (2023-09-27)
 

--- a/xradar/io/backends/furuno.py
+++ b/xradar/io/backends/furuno.py
@@ -362,8 +362,10 @@ class FurunoFile:
                 self._data[item] = data[:, i, :]
             # get angles
             angles = raw_data[:, :4].reshape(rays, 4)
+            # need to promote to uint32 to prevent integer overflow
+            # https://github.com/openradar/xradar/issues/137
             self._data["azimuth"] = np.fmod(
-                angles[:, 1] + self.header["azimuth_offset"], 36000
+                angles[:, 1].astype("uint32") + self.header["azimuth_offset"], 36000
             )
             # elevation angles are dtype "int16"
             # which was tested against a sweep with -1deg elevation


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #137 
- [x] Changes are documented in `history.md`
