### PR TITLE
FIX: explicitely check for "False" in get_crs()

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,7 +1,8 @@
 # History
 
 ## Development Version
-* FIX: Fix handling of sweep_mode attribiutes ({pull}`143`) by [@mgrover1](https://github.com/mgrover1)
+* FIX: Fix handling of sweep_mode attributes ({pull}`143`) by [@mgrover1](https://github.com/mgrover1)
+* FIX: explicitely check for "False" in get_crs() {pull}`142`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 
 ## 0.4.1 (2023-10-26)
 

--- a/xradar/georeference/projection.py
+++ b/xradar/georeference/projection.py
@@ -77,7 +77,7 @@ def get_crs(ds, datum="WGS84"):
         if "spatial_ref" in ds
         else False
     )
-    if crs_wkt:
+    if crs_wkt is not False:
         proj_crs = pyproj.CRS.from_cf(crs_wkt.attrs)
     else:
         proj_crs = pyproj.CRS(


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Changes are documented in `history.md`

Currently this will always return AEQD crs instead of the one in crs_wkt since the current check just checks for `True`. It fails since crs_wkt is a variable with value 0.   
