### PR TITLE
FIX: Fix handling of sweep_mode attribiutes

### DIFF
--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -73,6 +73,7 @@ def test_open_cfradial1_datatree(cfradial1_file):
             "range",
         }
         assert np.round(ds.sweep_fixed_angle.values.item(), 1) == elevations[i]
+        assert ds.sweep_mode == "azimuth_surveillance"
 
 
 def test_open_cfradial1_dataset(cfradial1_file):

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -155,8 +155,8 @@ def _get_sweep_groups(
         swslice = slice(i, i + 1)
         ds = data.isel(time=tslice, sweep=swslice).squeeze("sweep")
 
-        sweep_mode = _maybe_decode(ds.sweep_mode).compute()
-        dim0 = "elevation" if sweep_mode == "rhi" else "azimuth"
+        ds["sweep_mode"] = _maybe_decode(ds.sweep_mode).compute()
+        dim0 = "elevation" if ds["sweep_mode"] == "rhi" else "azimuth"
 
         # check and extract for variable number of gates
         if ray_n_gates is not False:

--- a/xradar/io/backends/common.py
+++ b/xradar/io/backends/common.py
@@ -24,7 +24,12 @@ from datatree import DataTree
 
 def _maybe_decode(attr):
     try:
-        return attr.decode()
+        # Decode the xr.DataArray differently than a byte string
+        if type(attr) == xr.core.dataarray.DataArray:
+            decoded_attr = attr.astype(str).str.rstrip()
+        else:
+            decoded_attr = attr.decode()
+        return decoded_attr
     except AttributeError:
         return attr
 


### PR DESCRIPTION
We currently do not decode the sweep_mode attributes properly with the cfradial reader, and the common decoder used in the readers does not fully handle xr.DataArray data structures. This adds a fix, along with a test to ensure we are handling this properly

- [ ] Tests added
- [ ] Changes are documented in `history.md`
