### PR TITLE
MNT: use CODECOV token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
         env_vars: RUNNER_OS,PYTHON_VERSION
         name: codecov-gha
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN}}
 
   build_1:
     name: xradar notebook tests - linux
@@ -118,6 +119,7 @@ jobs:
         env_vars: RUNNER_OS,PYTHON_VERSION
         name: codecov-gha
         fail_ci_if_error: false
+        token: ${{ secrets.CODECOV_TOKEN}}
 
 
   test_build_distribution_testpypi:

--- a/docs/history.md
+++ b/docs/history.md
@@ -4,6 +4,7 @@
 
 * MNT: Update GitHub actions, address DeprecationWarnings ({pull}`153`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 * MNT: restructure odim.py/gamic.py, add test_odim.py/test_gamic.py ({pull}`154`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
+* MNT: use CODECOV token ({pull}`155`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 
 ## 0.4.3 (2024-02-24)
 


### PR DESCRIPTION
Tokenless coverage upload is only available for PR with latest codecov-action. This adds the token to the CI run, to upload coverage on merges etc. Token is already present in repo secrets.

<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Changes are documented in `history.md`
