### PR TITLE
FIX: Add the proper elevation angle to fixed angle

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -7,6 +7,7 @@
 * MNT: use CODECOV token ({pull}`155`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 * MNT: fix path for notebook coverage ({pull}`157`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 * ADD: NEXRAD Level2 structured reader ({pull}`158`) by [@kmuehlbauer](https://github.com/kmuehlbauer) and [@mgrover1](https://github.com/mgrover1).
+* FIX: Add the proper elevation angle to fixed angle ({pull}`162`) by [@mgrover1](https://github.com/mgrover1).
 
 ## 0.4.3 (2024-02-24)
 

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -6,6 +6,7 @@
 
 from collections import OrderedDict
 
+import numpy as np
 import pytest
 import xarray
 
@@ -26,6 +27,7 @@ def test_open_nexradlevel2_datatree(nexradlevel2_files):
     assert ds["DBZH"].shape == (720, 1832)
     assert ds["DBZH"].dims == ("azimuth", "range")
     assert int(ds.sweep_number.values) == 0
+    np.testing.assert_almost_equal(ds.sweep_fixed_angle.values, 0.4833984)
 
 
 @pytest.mark.parametrize(

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1359,7 +1359,7 @@ class NexradLevel2Store(AbstractDataStore):
         prt_mode = "not_set"
         follow_mode = "not_set"
 
-        fixed_angle = self.root.msg_5["elevation_data"][self._group]
+        fixed_angle = self.root.msg_5["elevation_data"][self._group]["elevation_angle"]
 
         coords = {
             "azimuth": Variable((dim,), azimuth, get_azimuth_attrs(), encoding),


### PR DESCRIPTION
Ensure the elevation angle is unpacked into the fixed angle variable, giving a numerical value instead of the ordered dictionary

- [x] Closes #161 
- [x] Tests added
- [x] Changes are documented in `history.md`
