### PR TITLE
ENH: Add a utility for finding sweep number keys

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -8,6 +8,7 @@
 * MNT: fix path for notebook coverage ({pull}`157`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 * ADD: NEXRAD Level2 structured reader ({pull}`158`) by [@kmuehlbauer](https://github.com/kmuehlbauer) and [@mgrover1](https://github.com/mgrover1).
 * FIX: Add the proper elevation angle to fixed angle ({pull}`162`) by [@mgrover1](https://github.com/mgrover1).
+* ENH: Add a utility for finding sweep number keys ({pull}`167`) by [@mgrover1](https://github.com/mgrover1).
 
 ## 0.4.3 (2024-02-24)
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -9,7 +9,7 @@ import pytest
 import xarray as xr
 from open_radar_data import DATASETS
 
-from xradar import model, util
+from xradar import io, model, util
 
 
 @pytest.fixture(
@@ -254,3 +254,11 @@ def test_ipol_time2(missing, a1gate, rot):
             UserWarning, match="Rays might miss on beginning and/or end of sweep."
         ):
             dsx.pipe(util.ipol_time, direction=direction)
+
+
+def test_get_sweep_keys():
+    # Test finding sweep keys
+    filename = DATASETS.fetch("sample_sgp_data.nc")
+    dt = io.open_cfradial1_datatree(filename)
+    keys = util.get_sweep_keys(dt)
+    assert keys == ["sweep_0", "sweep_1", "sweep_2", "sweep_3", "sweep_4", "sweep_5"]

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -260,5 +260,7 @@ def test_get_sweep_keys():
     # Test finding sweep keys
     filename = DATASETS.fetch("sample_sgp_data.nc")
     dt = io.open_cfradial1_datatree(filename)
+    # set a fake group
+    dt["sneep_1"] = dt["sweep_1"]
     keys = util.get_sweep_keys(dt)
     assert keys == ["sweep_0", "sweep_1", "sweep_2", "sweep_3", "sweep_4", "sweep_5"]

--- a/xradar/util.py
+++ b/xradar/util.py
@@ -509,9 +509,16 @@ def get_sweep_keys(dt):
         try:
             # Try to set the second part of the tree key to an int
             int(parts[1])
+            # Check for "sweep" in the first part of the key
+            assert "sweep" in parts[0]
             sweep_group_keys.append(key)
 
         # This would fail with strings - ex. sweep_group_attrs
         except ValueError:
             pass
+
+        # This would fail if "sweep" not in key - ex. radar_parameters
+        except AssertionError:
+            pass
+
     return sweep_group_keys

--- a/xradar/util.py
+++ b/xradar/util.py
@@ -22,6 +22,7 @@ __all__ = [
     "extract_angle_parameters",
     "ipol_time",
     "rolling_dim",
+    "get_sweep_keys",
 ]
 
 __doc__ = __doc__.format("\n   ".join(__all__))
@@ -487,3 +488,30 @@ def rolling_dim(data, window):
     shape = data.shape[:-1] + (data.shape[-1] - window + 1, window)
     strides = data.strides + (data.strides[-1],)
     return np.lib.stride_tricks.as_strided(data, shape=shape, strides=strides)
+
+
+def get_sweep_keys(dt):
+    """Return which nodes in the datatree contain sweep variables
+
+    Parameters
+    ----------
+    dt : xarray.DataTree
+        Datatree to check for sweep_n keys
+
+    Returns
+    -------
+    keys : list
+        List of associated keys with sweep_n
+    """
+    sweep_group_keys = []
+    for key in list(dt.children):
+        parts = key.split("_")
+        try:
+            # Try to set the second part of the tree key to an int
+            int(parts[1])
+            sweep_group_keys.append(key)
+
+        # This would fail with strings - ex. sweep_group_attrs
+        except ValueError:
+            pass
+    return sweep_group_keys


### PR DESCRIPTION
Add a utility to find the `sweep_n` keys in a given datatree. This will help with downstream applications, especially with Py-ART, and since this information will be stored in the core data model.

- [x] Tests added
- [x] Changes are documented in `history.md`
