### PR TITLE
ADD: Add Alfonso to citation doc

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -23,6 +23,10 @@ authors:
   family-names: Syed
   affiliation: Purdue University
   orcid: https://orcid.org/0000-0002-7188-2544
+- given-names: Alfonso
+  family-names: Ladino
+  affiliation: University of Illinois at Urbana Champaign
+  orcid: https://orcid.org/0000-0001-8081-7827
 version: 0.4.0
 date-released: 2023-09-27
 repository-code: https://github.com/openradar/xradar

--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development Version (unreleased)
 
+* ADD: Add Alfonso to citation doc ({pull}`169`) by [@mgrover1](https://github.com/mgrover1)
 * ENH: Adding global variables and attributes to iris datatree ({pull}`166`) by [@aladinor](https://github.com/aladinor)
 
 ## 0.5.0 (2024-03-28)


### PR DESCRIPTION
Add @aladinor to the citation document, which will ensure he is listed in the Zenodo DOI.

- [x] Changes are documented in `history.md`
