### PR TITLE
FIX: set fillvalue before applying scale/offset when exporting odim

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -4,6 +4,7 @@
 
 * ADD: Add Alfonso to citation doc ({pull}`169`) by [@mgrover1](https://github.com/mgrover1)
 * ENH: Adding global variables and attributes to iris datatree ({pull}`166`) by [@aladinor](https://github.com/aladinor)
+* FIX: Set fillvalue before applying scale/offset when exporting to odim ({issue}`122`) by [@pavlikp](https://github.com/pavlikp), ({pull}`173`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 
 ## 0.5.0 (2024-03-28)
 

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -110,8 +110,8 @@ def _write_odim_dataspace(source, destination, compression, compression_opts):
         val = value.sortby(dim0).values
         fillval = _fillvalue * scale_factor
         fillval += add_offset
-        val = (val - add_offset) / scale_factor
         val[np.isnan(val)] = fillval
+        val = (val - add_offset) / scale_factor
         if np.issubdtype(dtype, np.integer):
             val = np.rint(val).astype(dtype)
         ds = h5_data.create_dataset(


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #122
- [ ] Tests added
- [x] Changes are documented in `history.md`
