### PR TITLE
ADD: New feature to attach lat, lon, and alt

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,8 @@
 
 ## 0.8.1 (Unreleased)
 
+* ENH: Added georeferencing for Cartesian (x, y, z) and geographic (lat, lon, alt) coordinates in radar data processing ({issue}`243`) by [@syedhamidali](https://github.com/syedhamidali), ({pull}`244`) by [@syedhamidali](https://github.com/syedhamidali)
+
 * ENH: Adding test to `open_datatree` function for all backends. Adding "scan_name" to nexradlevel2 datatree attributes ({pull}`238`) by [@aladinor](https://github.com/aladinor)
 * FIX: Improving performance of `open_nexradlevel2_datatree` function and adding tests for `sweep` parameter. ({issue}`239`) ({pull}`240`) by [@aladinor](https://github.com/aladinor)
 * FIX: Keeping attributes at each variable when using `open_nexradlevel2_datatree`. ({issue}`241`) ({pull}`242`) by [@aladinor](https://github.com/aladinor)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -48,4 +48,5 @@ notebooks/angle_reindexing
 notebooks/Multi-Volume-Concatenation.ipynb
 notebooks/multiple-sweeps-into-volume-scan.ipynb
 notebooks/Transform
+notebooks/georeferencing
 ```

--- a/examples/notebooks/georeferencing.ipynb
+++ b/examples/notebooks/georeferencing.ipynb
@@ -1,0 +1,395 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "# Georeferencing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1",
+   "metadata": {},
+   "source": [
+    "This notebook shows how to add Cartesian (x, y, z) and geographic (lat, lon, alt) coordinates to radar data using xradar.\n",
+    "\n",
+    "\n",
+    "- **DataTree** refers to [xarray.DataTree](https://docs.xarray.dev/en/stable/generated/xarray.DataTree.html#xarray.DataTree)\n",
+    "- **Dataset** refers to [xarray.Dataset](https://docs.xarray.dev/en/stable/generated/xarray.Dataset.html#xarray.Dataset)\n",
+    "- **DataArray** refers to [xarray.DataArray](https://docs.xarray.dev/en/stable/generated/xarray.DataArray.html#xarray.DataArray)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xradar as xd\n",
+    "import xarray as xr\n",
+    "import cmweather\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib.ticker as ticker\n",
+    "from open_radar_data import DATASETS\n",
+    "import warnings\n",
+    "\n",
+    "warnings.simplefilter(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "## Read Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "file = DATASETS.fetch(\"sample_rainbow_5_59.vol\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar = xd.io.open_rainbow_datatree(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6",
+   "metadata": {},
+   "source": [
+    "## Georeferencing (Cartesian)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar = radar.xradar.georeference()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(radar[\"sweep_0\"].ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9",
+   "metadata": {},
+   "source": [
+    "- **Notice that the radar DataTree now includes x, y, and z coordinates.**\n",
+    "- **Next, let’s add lat, lon, and alt coordinates.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del radar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## Georeferencing (Geographic)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading data again\n",
+    "radar = xd.io.open_rainbow_datatree(file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar = radar.xradar.georeference(geo=True)\n",
+    "display(radar[\"sweep_0\"].ds)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14",
+   "metadata": {},
+   "source": [
+    "- **When geo=True, lat, lon, and alt coordinates are added instead.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del radar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "16",
+   "metadata": {},
+   "source": [
+    "## Other Uses"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "17",
+   "metadata": {},
+   "source": [
+    "- **You can also add these coordinates to a single DataArray or Dataset.**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading data again\n",
+    "radar = xd.io.open_rainbow_datatree(file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## Assign both cartesian and geographic coords"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "radar = radar.xradar.georeference().xradar.georeference(geo=True)\n",
+    "display(radar[\"sweep_0\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "del radar"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "## Assign to Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reading data again\n",
+    "radar = xd.io.open_rainbow_datatree(file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = radar[\"sweep_0\"].to_dataset()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "display(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Attach both types of coords\n",
+    "ds = ds.xradar.georeference().xradar.georeference(geo=True)\n",
+    "display(ds)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = ds.drop(labels=[\"x\", \"y\", \"z\", \"lat\", \"lon\", \"alt\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "28",
+   "metadata": {},
+   "source": [
+    "## Assign to DataArray"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivity = ds[\"DBZH\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "reflectivity = reflectivity.xradar.georeference().xradar.georeference(geo=True)\n",
+    "display(reflectivity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "31",
+   "metadata": {},
+   "source": [
+    "## Plot"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig, ax = plt.subplots(1, 2, figsize=(10, 5.5))\n",
+    "\n",
+    "# Cartesian plot with x, y in km\n",
+    "reflectivity.plot(\n",
+    "    x=\"x\",\n",
+    "    y=\"y\",\n",
+    "    add_colorbar=False,\n",
+    "    vmin=-10,\n",
+    "    vmax=60,\n",
+    "    cmap=\"NWSRef\",\n",
+    "    ax=ax[0],\n",
+    ")\n",
+    "ax[0].set_title(\"Reflectivity (Cartesian)\")\n",
+    "ax[0].xaxis.set_major_formatter(ticker.FuncFormatter(lambda val, pos: f\"{val/1e3:.0f}\"))\n",
+    "ax[0].yaxis.set_major_formatter(ticker.FuncFormatter(lambda val, pos: f\"{val/1e3:.0f}\"))\n",
+    "ax[0].set_xlabel(\"x (km)\")\n",
+    "ax[0].set_ylabel(\"y (km)\")\n",
+    "\n",
+    "# Geographic plot with lon, lat\n",
+    "pl = reflectivity.plot(\n",
+    "    x=\"lon\",\n",
+    "    y=\"lat\",\n",
+    "    add_colorbar=False,\n",
+    "    vmin=-10,\n",
+    "    vmax=60,\n",
+    "    cmap=\"NWSRef\",\n",
+    "    ax=ax[1],\n",
+    ")\n",
+    "ax[1].set_title(\"Reflectivity (Geographic)\")\n",
+    "ax[1].set_xlabel(\"Longitude\")\n",
+    "ax[1].set_ylabel(\"Latitude\")\n",
+    "\n",
+    "# Add a centered colorbar below the plots\n",
+    "cbar = fig.colorbar(pl, ax=ax, orientation=\"horizontal\", fraction=0.05, pad=-0.25)\n",
+    "cbar.set_label(\"Reflectivity (dBZ)\")\n",
+    "\n",
+    "for ax in ax.flat:\n",
+    "    ax.minorticks_on()\n",
+    "    ax.grid(ls=\"--\", lw=0.5)\n",
+    "\n",
+    "plt.tight_layout()\n",
+    "plt.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "33",
+   "metadata": {},
+   "source": [
+    "These transformations make radar data more versatile for analysis and visualization. You can apply these enhancements to entire DataTree structures or individual Dataset and DataArray objects, making xradar a flexible tool for radar data processing."
+   ]
+  }
+ ],
+ "metadata": {
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/notebooks/georeferencing.ipynb
+++ b/examples/notebooks/georeferencing.ipynb
@@ -30,7 +30,7 @@
    "source": [
     "import xradar as xd\n",
     "import xarray as xr\n",
-    "import cmweather\n",
+    "import cmweather  # noqa\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.ticker as ticker\n",
     "from open_radar_data import DATASETS\n",

--- a/examples/notebooks/georeferencing.ipynb
+++ b/examples/notebooks/georeferencing.ipynb
@@ -28,13 +28,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import xradar as xd\n",
-    "import xarray as xr\n",
+    "import warnings\n",
+    "\n",
     "import cmweather  # noqa\n",
     "import matplotlib.pyplot as plt\n",
     "import matplotlib.ticker as ticker\n",
     "from open_radar_data import DATASETS\n",
-    "import warnings\n",
+    "\n",
+    "import xradar as xd\n",
     "\n",
     "warnings.simplefilter(\"ignore\")"
    ]

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -14,40 +14,94 @@ def test_georeference_dataarray():
     radar = xd.model.create_sweep_dataset()
     radar["sample_field"] = radar.azimuth + radar.range
 
-    geo = radar.sample_field.xradar.georeference()
-    assert_almost_equal(geo.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407]))
+    # geo=True
+    geo_cartesian = radar.sample_field.xradar.georeference(geo=False)
     assert_almost_equal(
-        geo.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+        geo_cartesian.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407])
     )
     assert_almost_equal(
-        geo.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
+        geo_cartesian.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+    )
+    assert_almost_equal(
+        geo_cartesian.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
+    )
+
+    # geo=True
+    radar = xd.model.create_sweep_dataset().swap_dims({"time": "azimuth"})
+    radar["sample_field"] = radar.azimuth + radar.range
+
+    geo_geographic = radar.sample_field.xradar.georeference(geo=True)
+    assert_almost_equal(
+        geo_geographic.lon.values[:3, 0], np.array([8.7877327, 8.7877441, 8.7877554])
+    )
+    assert_almost_equal(
+        geo_geographic.lat.values[:3, 0],
+        np.array([46.1729908, 46.1729907, 46.17299042]),
+    )
+    assert_almost_equal(
+        geo_geographic.alt.values[:3, 0],
+        np.array([375.87276751, 375.87276751, 375.87276751]),
     )
 
 
 def test_georeference_dataset():
     radar = xd.model.create_sweep_dataset()
-    geo = radar.xradar.georeference()
-    assert_almost_equal(geo.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407]))
+    geo_cartesian = radar.xradar.georeference(geo=False)
     assert_almost_equal(
-        geo.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+        geo_cartesian.x.values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407])
     )
     assert_almost_equal(
-        geo.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
+        geo_cartesian.y.values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+    )
+    assert_almost_equal(
+        geo_cartesian.z.values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
+    )
+
+    # geo=True
+    radar = xd.model.create_sweep_dataset().swap_dims({"time": "azimuth"})
+    geo_geographic = radar.xradar.georeference(geo=True)
+    assert_almost_equal(
+        geo_geographic.lon.values[:3, 0], np.array([8.7877327, 8.7877441, 8.7877554])
+    )
+    assert_almost_equal(
+        geo_geographic.lat.values[:3, 0],
+        np.array([46.1729908, 46.1729907, 46.17299042]),
+    )
+    assert_almost_equal(
+        geo_geographic.alt.values[:3, 0],
+        np.array([375.87276751, 375.87276751, 375.87276751]),
     )
 
 
 def test_georeference_datatree():
     radar = xd.model.create_sweep_dataset()
     tree = xr.DataTree.from_dict({"sweep_0": radar})
-    geo = tree.xradar.georeference()["sweep_0"]
+    geo_cartesian = tree.xradar.georeference(geo=False)["sweep_0"]
     assert_almost_equal(
-        geo["x"].values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407])
+        geo_cartesian["x"].values[:3, 0], np.array([0.436241, 1.3085901, 2.1805407])
     )
     assert_almost_equal(
-        geo["y"].values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
+        geo_cartesian["y"].values[:3, 0], np.array([49.9882679, 49.973041, 49.9425919])
     )
     assert_almost_equal(
-        geo["z"].values[:3, 0], np.array([375.8727675, 375.8727675, 375.8727675])
+        geo_cartesian["z"].values[:3, 0],
+        np.array([375.8727675, 375.8727675, 375.8727675]),
+    )
+
+    # geo=True
+    radar = xd.model.create_sweep_dataset().swap_dims({"time": "azimuth"})
+    tree = xr.DataTree.from_dict({"sweep_0": radar})
+    geo_geographic = tree.xradar.georeference(geo=True)["sweep_0"]
+    assert_almost_equal(
+        geo_geographic.lon.values[:3, 0], np.array([8.7877327, 8.7877441, 8.7877554])
+    )
+    assert_almost_equal(
+        geo_geographic.lat.values[:3, 0],
+        np.array([46.1729908, 46.1729907, 46.17299042]),
+    )
+    assert_almost_equal(
+        geo_geographic.alt.values[:3, 0],
+        np.array([375.87276751, 375.87276751, 375.87276751]),
     )
 
 

--- a/xradar/accessors.py
+++ b/xradar/accessors.py
@@ -27,7 +27,14 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 
 import xarray as xr
 
-from .georeference import add_crs, add_crs_tree, get_crs, get_x_y_z, get_x_y_z_tree
+from .georeference import (
+    add_crs,
+    add_crs_tree,
+    get_crs,
+    get_lat_lon_alt,
+    get_x_y_z,
+    get_x_y_z_tree,
+)
 from .transform import to_cfradial1, to_cfradial2
 from .util import map_over_sweeps
 
@@ -73,7 +80,7 @@ class XradarDataArrayAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to xarray.DataArray objects."""
 
     def georeference(
-        self, earth_radius=None, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None, geo=False
     ) -> xr.DataArray:
         """
         Parameters
@@ -90,8 +97,13 @@ class XradarDataArrayAccessor(XradarAccessor):
         """
         radar = self.xarray_obj
 
+        if geo:
+            func = get_lat_lon_alt
+        else:
+            func = get_x_y_z
+
         return radar.pipe(
-            get_x_y_z,
+            func,
             earth_radius=earth_radius,
             effective_radius_fraction=effective_radius_fraction,
         )
@@ -123,7 +135,7 @@ class XradarDataSetAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to xarray.DataArray objects."""
 
     def georeference(
-        self, earth_radius=None, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None, geo=False
     ) -> xr.Dataset:
         """
         Add georeference information to an xarray dataset
@@ -140,8 +152,13 @@ class XradarDataSetAccessor(XradarAccessor):
             Dataset including x, y, and z as coordinates.
         """
         radar = self.xarray_obj
+        if geo:
+            func = get_lat_lon_alt
+        else:
+            func = get_x_y_z
+
         return radar.pipe(
-            get_x_y_z,
+            func,
             earth_radius=earth_radius,
             effective_radius_fraction=effective_radius_fraction,
         )
@@ -185,7 +202,7 @@ class XradarDataTreeAccessor(XradarAccessor):
     """Adds a number of xradar specific methods to xarray.DataTree objects."""
 
     def georeference(
-        self, earth_radius=None, effective_radius_fraction=None
+        self, earth_radius=None, effective_radius_fraction=None, geo=False
     ) -> xr.DataTree:
         """
         Add georeference information to an xradar datatree object
@@ -202,10 +219,12 @@ class XradarDataTreeAccessor(XradarAccessor):
             Datatree including x, y, and z as coordinates.
         """
         radar = self.xarray_obj
+
         return radar.pipe(
             get_x_y_z_tree,
             earth_radius=earth_radius,
             effective_radius_fraction=effective_radius_fraction,
+            geo=geo,
         )
 
     def add_crs(self) -> xr.DataTree:


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #243 
- [x] Tests added
- [ ] Changes are documented in `history.md`

### Description
This PR is for the ability to include geographic coordinates (lat, lon, and alt) in xradar’s georeferencing accessor.

### Usage

To enable geographic georeferencing
```python
geo = radar.xradar.georeference(geo=True)
```