### PR TITLE
FIX: RHIs now work with Halo Photonics Reader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
             h5py
             lat_lon_parser
             netCDF4
-            open-radar-data>=0.3.0
+            open-radar-data>=0.4.2
             packaging
             pandas
             pip

--- a/ci/notebooktests.yml
+++ b/ci/notebooktests.yml
@@ -16,7 +16,7 @@ dependencies:
   - netCDF4
   - notebook
   - numpy
-  - open-radar-data>0.4.2
+  - open-radar-data>=0.4.2
   - pip
   - pyproj
   - pytest

--- a/ci/notebooktests.yml
+++ b/ci/notebooktests.yml
@@ -16,7 +16,7 @@ dependencies:
   - netCDF4
   - notebook
   - numpy
-  - open-radar-data>=0.3.0
+  - open-radar-data>0.4.2
   - pip
   - pyproj
   - pytest

--- a/ci/unittests.yml
+++ b/ci/unittests.yml
@@ -13,7 +13,7 @@ dependencies:
   - lat_lon_parser
   - netCDF4
   - numpy
-  - open-radar-data>=0.3.0
+  - open-radar-data>=0.4.2
   - pip
   - pyproj
   - pytest

--- a/docs/history.md
+++ b/docs/history.md
@@ -5,6 +5,7 @@
 * ENH: Adding test to `open_datatree` function for all backends. Adding "scan_name" to nexradlevel2 datatree attributes ({pull}`238`) by [@aladinor](https://github.com/aladinor)
 * FIX: Improving performance of `open_nexradlevel2_datatree` function and adding tests for `sweep` parameter. ({issue}`239`) ({pull}`240`) by [@aladinor](https://github.com/aladinor)
 * FIX: Keeping attributes at each variable when using `open_nexradlevel2_datatree`. ({issue}`241`) ({pull}`242`) by [@aladinor](https://github.com/aladinor)
+* FIX: Correctly read transition rays in RHI scans ({issue}`247`) ({pull}`250`) by [@rcjackson](https://github.com/rcjackson)
 
 ## 0.8.0 (2024-11-04)
 

--- a/examples/notebooks/HaloPhotonics.ipynb
+++ b/examples/notebooks/HaloPhotonics.ipynb
@@ -67,7 +67,7 @@
    "source": [
     "fig, ax = plt.subplots(3, 3, figsize=(12, 10))\n",
     "for sweep in range(9):\n",
-    "    sweep_ds = xd.georeference.get_x_y_z(ds[\"sweep_%d\" % sweep].ds)\n",
+    "    sweep_ds = xd.georeference.get_x_y_z(ds[f\"sweep_{sweep:d}\"].ds)\n",
     "    sweep_ds = sweep_ds.set_coords([\"x\", \"y\", \"z\", \"time\", \"range\"])\n",
     "    sweep_ds[\"mean_doppler_velocity\"].plot(\n",
     "        x=\"x\", y=\"y\", ax=ax[int(sweep / 3), sweep % 3]\n",

--- a/examples/notebooks/conftest.py
+++ b/examples/notebooks/conftest.py
@@ -30,7 +30,7 @@ class NotebookFile(pytest.File):
             yield NotebookItem.from_parent(self, name=os.path.basename(f))
 
     def setup(self):
-        kernel = "python%d" % sys.version_info[0]         # noqa
+        kernel = "python%d" % sys.version_info[0]  # noqa
         self.exproc = ExecutePreprocessor(kernel_name=kernel, timeout=600)
 
 

--- a/examples/notebooks/conftest.py
+++ b/examples/notebooks/conftest.py
@@ -30,7 +30,7 @@ class NotebookFile(pytest.File):
             yield NotebookItem.from_parent(self, name=os.path.basename(f))
 
     def setup(self):
-        kernel = "python%d" % sys.version_info[0]
+        kernel = "python%d" % sys.version_info[0]         # noqa
         self.exproc = ExecutePreprocessor(kernel_name=kernel, timeout=600)
 
 

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -34,7 +34,7 @@ def test_open_dataset_hpl():
 
 
 def test_open_dataset_hpl_iobase():
-    with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:    # noqa
+    with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:  # noqa
         ds = xr.open_dataset(
             fi, engine="hpl", backend_kwargs=dict(latitude=40, longitude=-70)
         )

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -26,12 +26,22 @@ def test_open_dataset_hpl():
     with xr.open_dataset(
         DATASETS.fetch("User1_184_20240601_013257.hpl"),
         engine="hpl",
-        backend_kwargs=dict(latitude=41.24276244459537, longitude=-70.1070364814594),
+        backend_kwargs=dict(latitude=40, longitude=-70),
     ) as ds:
 
         assert ds["mean_doppler_velocity"].dims == ("azimuth", "range")
         assert ds["mean_doppler_velocity"].max() == 19.5306
 
+
+def test_open_rhi():
+    with xr.open_dataset(
+        DATASETS.fetch("User1_100_20240714_122137.hpl"),
+        engine="hpl",
+        backend_kwargs=dict(latitude=41.24276244459537, longitude=-70.1070364814594),
+    ) as ds:
+        
+        assert ds["mean_doppler_velocity"].dims == ("azimuth", "range")
+        assert ds["mean_doppler_velocity"].max() == 19.5306
 
 def test_open_hpl_datatree():
     # Define the kwargs to pass into the function

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -35,9 +35,9 @@ def test_open_dataset_hpl():
 
 def test_open_dataset_hpl_iobase():
     with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:
-        ds = xr.open_dataset(fi,
-            engine="hpl",
-            backend_kwargs=dict(latitude=40, longitude=-70))
+        ds = xr.open_dataset(
+            fi, engine="hpl", backend_kwargs=dict(latitude=40, longitude=-70)
+        )
 
         assert ds["mean_doppler_velocity"].dims == ("azimuth", "range")
         assert ds["mean_doppler_velocity"].max() == 19.5306

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -33,15 +33,26 @@ def test_open_dataset_hpl():
         assert ds["mean_doppler_velocity"].max() == 19.5306
 
 
+def test_open_dataset_hpl_iobase():
+    with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:
+        ds = xr.open_dataset(fi,
+            engine="hpl",
+            backend_kwargs=dict(latitude=40, longitude=-70))
+
+        assert ds["mean_doppler_velocity"].dims == ("azimuth", "range")
+        assert ds["mean_doppler_velocity"].max() == 19.5306
+
+
 def test_open_rhi():
     with xr.open_dataset(
         DATASETS.fetch("User1_100_20240714_122137.hpl"),
         engine="hpl",
         backend_kwargs=dict(latitude=41.24276244459537, longitude=-70.1070364814594),
     ) as ds:
-        
+
         assert ds["mean_doppler_velocity"].dims == ("azimuth", "range")
         assert ds["mean_doppler_velocity"].max() == 19.5306
+
 
 def test_open_hpl_datatree():
     # Define the kwargs to pass into the function

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -34,7 +34,7 @@ def test_open_dataset_hpl():
 
 
 def test_open_dataset_hpl_iobase():
-    with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:
+    with open(DATASETS.fetch("User1_184_20240601_013257.hpl"), "r") as fi:    # noqa
         ds = xr.open_dataset(
             fi, engine="hpl", backend_kwargs=dict(latitude=40, longitude=-70)
         )

--- a/xradar/io/backends/hpl.py
+++ b/xradar/io/backends/hpl.py
@@ -378,7 +378,7 @@ class HplFile:
                     sweep_dict[k] = data_unsorted[k][time_inds]
                 else:
                     sweep_dict[k] = data_unsorted[k]
-            self._data["sweep_%d" % i] = sweep_dict
+            self._data[f"sweep_{i:d}"] = sweep_dict
         self._data["sweep_number"] = data_unsorted["sweep_number"]
         self._data["fixed_angle"] = data_unsorted["fixed_angle"]
 

--- a/xradar/io/backends/hpl.py
+++ b/xradar/io/backends/hpl.py
@@ -322,11 +322,13 @@ class HplFile:
             data_unsorted["azimuth"] - 360.0,
         )
         if data_unsorted["sweep_mode"] == "rhi":
-            data_unsorted["fixed_angle"] = np.unique(
-                data_unsorted["azimuth"].data[
-                    np.argwhere(np.abs(diff_azimuth) <= transition_threshold_azi) + 1
-                ]
+            non_transitions = (
+                np.argwhere(np.abs(diff_azimuth) <= transition_threshold_azi) + 1
             )
+            unique_elevations = np.unique(
+                data_unsorted["azimuth"][np.squeeze(non_transitions)]
+            )
+            data_unsorted["fixed_angle"] = unique_elevations
         elif (
             data_unsorted["sweep_mode"] == "azimuth_surveillance"
             or data_unsorted["sweep_mode"] == "vertical_pointing"
@@ -343,8 +345,11 @@ class HplFile:
         )
         start_indicies = []
         end_indicies = []
-        for i, t in enumerate(unique_elevations):
-            where_in_sweep = np.argwhere(data_unsorted["elevation"] == t)
+        for i, t in enumerate(data_unsorted["fixed_angle"]):
+            if data_unsorted["sweep_mode"] == b"rhi":
+                where_in_sweep = np.argwhere(data_unsorted["azimuth"] == t)
+            else:
+                where_in_sweep = np.argwhere(data_unsorted["elevation"] == t)
             start_indicies.append(int(where_in_sweep.min()))
             end_indicies.append(int(where_in_sweep.max()))
         end_indicies = np.array(end_indicies)
@@ -353,7 +358,7 @@ class HplFile:
         data_unsorted["sweep_end_ray_index"] = np.array(end_indicies)
         data_unsorted["antenna_transition"] = transitions
         self._data = OrderedDict()
-        for i in range(len(unique_elevations)):
+        for i in range(len(data_unsorted["fixed_angle"])):
             sweep_dict = OrderedDict()
             time_inds = slice(
                 data_unsorted["sweep_start_ray_index"][i],
@@ -531,6 +536,8 @@ class HPLBackendEntrypoint(BackendEntrypoint):
         latitude=0,
         longitude=0,
         altitude=0,
+        transition_threshold_azi=0.05,
+        transition_threshold_el=0.001,
     ):
         store_entrypoint = StoreBackendEntrypoint()
 
@@ -544,6 +551,8 @@ class HPLBackendEntrypoint(BackendEntrypoint):
             latitude=latitude,
             longitude=longitude,
             altitude=altitude,
+            transition_threshold_azi=transition_threshold_azi,
+            transition_threshold_el=transition_threshold_el,
         )
 
         ds = store_entrypoint.open_dataset(


### PR DESCRIPTION
This fixes the error shown in PR #247 when an RHI was being loaded by the Halo Photonics reader.

- [x] Closes #247 
- [x] Changes are documented in `history.md`
