### PR TITLE
FIX datatree reader now works with sweeps containing different variables

### DIFF
--- a/xradar/io/backends/common.py
+++ b/xradar/io/backends/common.py
@@ -240,7 +240,7 @@ def _get_required_root_dataset(ls_ds, optional=True):
         remove_root ^= set(optional_root_vars)
     remove_root ^= {"sweep_number", "fixed_angle"}
     remove_root &= data_var
-    root = [sweep.drop_vars(remove_root) for sweep in ls_ds]
+    root = [sweep.drop_vars(remove_root, errors="ignore") for sweep in ls_ds]
     root_vars = {x for xs in [sweep.variables.keys() for sweep in root] for x in xs}
     # rename variables
     # todo: find a more easy method not iterating over all variables


### PR DESCRIPTION
This is a quick fix to allow reading radar data containing different variables from sweep to sweep.

I would like to share my experience with contributing. Running the tests failed after following the instructions. I had to do a significant analysis and several test runs. I am not an expert in packaging but I suggest to add the following python packages to the requirement list: 

open_radar_data
jupyter
cartopy
boto3
s3fs
zarr

_ffmpeg_ is also required
