### PR TITLE
ADD: function to select dataset variables in sweep

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -1,7 +1,10 @@
 # History
 
 ## Development Version
-
+* ADD: function to select dataset variables in sweep ({issue}`104`) ({pull}`254`) by [@egouden](https://github.com/egouden)
+* ADD: function to get dataset variables in sweep
+* ADD: function to get metadata variables in sweep
+* FIX: typo in accessors module: Dataarray -> Dataset
 * FIX: Update missing deps for virtualenv environments via "requirements_dev.txt". ({issue}`253`) ({pull}`274`) by [@Steve-Roderick](https://github.com/Steve-Roderick).
 
 ## 0.9.0 (2025-02-07)

--- a/xradar/accessors.py
+++ b/xradar/accessors.py
@@ -120,7 +120,7 @@ class XradarDataArrayAccessor(XradarAccessor):
 
 @xr.register_dataset_accessor("xradar")
 class XradarDataSetAccessor(XradarAccessor):
-    """Adds a number of xradar specific methods to xarray.DataArray objects."""
+    """Adds a number of xradar specific methods to xarray.Dataset objects."""
 
     def georeference(
         self, earth_radius=None, effective_radius_fraction=None


### PR DESCRIPTION
The WMO conventions define two types of data variables for the sweep object:
- dataset variables, with dimension of time and range (e.g. DBZH, RR, quality1, ...)
- metadata variables, typically a scalar (e.g. sweep_number, sweep_mode, polarization_mode, ...)

These variables can be accessed together by the _data_vars_ property of the sweep object (xarray Dataset). However it is not possible to make the distinction between the two types of variables. Two new functions allow to access these variables separately.

It is possible to select dataset variables directly using sweep[list of variables]. But this results in the loss of the metadata. A new function allows to select dataset variables while keeping metadata variables.