### PR TITLE
FIX: correct retrieval of intermediate records in nexrad level2 reader

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -8,6 +8,8 @@
 * FIX: Correctly read transition rays in RHI scans ({issue}`247`) ({pull}`250`) by [@rcjackson](https://github.com/rcjackson)
 * FIX: Correctly open NEXRAD files when split cut mode is enable ({issue} `245`) ({pull}`246`) by [@aladinor](https://github.com/aladinor)
 * ADD: Example Notebook for assigning geocoords. ({issue}`243`) and ({pull}`251`) by [@syedhamidali](https://github.com/syedhamidali)
+* FIX: DataTree reader now works with sweeps containing different variables ({pull}`252`) by [@egouden](https://github.com/egouden).
+* FIX: Correct retrieval of intermediate records in nexrad level2 reader ({issue}`259`) ({pull}`261`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 
 ## 0.8.0 (2024-11-04)
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1238,11 +1238,17 @@ class NexradLevel2ArrayWrapper(BackendArray):
         self.group = datastore._group
         self.name = name
         # get rays and bins
+        # retrieve number of intermediate records between record_number and record_end
+        intermediate = [
+            0
+            for irec in datastore.ds["intermediate_records"]
+            if irec["record_number"] <= datastore.ds["record_end"]
+        ]
         nrays = (
             datastore.ds["record_end"]
             - datastore.ds["record_number"]
             + 1
-            - len(datastore.ds["intermediate_records"])
+            - len(intermediate)
         )
         nbins = max([v["ngates"] for k, v in datastore.ds["sweep_data"].items()])
         word_size = datastore.ds["sweep_data"][name]["word_size"]


### PR DESCRIPTION
<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #259
- [ ] Tests added
- [x] Changes are documented in `history.md`
