### PR TITLE
FIX: test for BZhX1AY&SY (where X is any number between 0..9)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -10,6 +10,7 @@
 * ADD: Example Notebook for assigning geocoords. ({issue}`243`) and ({pull}`251`) by [@syedhamidali](https://github.com/syedhamidali)
 * FIX: DataTree reader now works with sweeps containing different variables ({pull}`252`) by [@egouden](https://github.com/egouden).
 * FIX: Correct retrieval of intermediate records in nexrad level2 reader ({issue}`259`) ({pull}`261`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
+* FIX: Test for magic number BZhX1AY&SY (where X is any number between 0..9) when retrieving BZ2 record indices in nexrad level2 reader ({issue}`264`) ({pull}`266`) by [@kmuehlbauer](https://github.com/kmuehlbauer).
 
 ## 0.8.0 (2024-11-04)
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -198,9 +198,10 @@ class NEXRADFile:
         """Get file offsets of bz2 records."""
         if self._bz2_indices is None:
             # magic number inside BZ2
-            seq = np.array([49, 65, 89, 38, 83, 89], dtype=np.uint8)
-            rd = util.rolling_dim(self._fh, 6)
-            self._bz2_indices = np.nonzero((rd == seq).all(1))[0] - 8
+            # BZhX1AY&SY (where X is any number between 0..9)
+            seq = np.array([66, 90, 104, 0, 49, 65, 89, 38, 83, 89], dtype=np.uint8)
+            rd = util.rolling_dim(self._fh, len(seq))
+            self._bz2_indices = np.nonzero((rd == seq).sum(1) >= 9)[0] - 4
         return self._bz2_indices
 
     @property


### PR DESCRIPTION
when retrieving bz2 record indices in nexradlevel2 reader

<!-- Please remove check-list items that aren't relevant to your changes -->

- [x] Closes #264 
- [ ] Tests added
- [x] Changes are documented in `history.md`
