### PR TITLE
    FIX: Add missing deps for virtualenv environments (#253)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,6 +63,8 @@ Ready to contribute? Here's how to set up `xradar` for local development.
     $ python -m pip install -e .[dev]
     ```
 
+3.1 Install `ffmpeg` using your OS package manager.
+
 4. Create a branch for local development:
 
     ```bash

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,5 +1,9 @@
 # History
 
+## Development Version
+
+* FIX: Update missing deps for virtualenv environments via "requirements_dev.txt". ({issue}`253`) ({pull}`274`) by [@Steve-Roderick](https://github.com/Steve-Roderick).
+
 ## 0.9.0 (2025-02-07)
 
 * ENH: Adding test to `open_datatree` function for all backends. Adding "scan_name" to nexradlevel2 datatree attributes ({pull}`238`) by [@aladinor](https://github.com/aladinor)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -10,3 +10,10 @@ pytest
 black
 isort
 fsspec
+nbconvert
+notebook
+open_radar_data
+boto3
+cartopy
+s3fs
+zarr>=2,<3


### PR DESCRIPTION
    * Add `cartopy` for test `examples/notebooks/Multi-Volume-Concatenation.ipynb`.
    * Add `boto3` for test `examples/notebooks/Read-plot-Sigmet-data-from-AWS.ipynb`.
    * Add `zarr` for test `examples/notebooks/multiple-sweeps-into-volume-scan.ipynb`.
    * Add `s3fs` for test `examples/notebooks/Read-plot-Sigmet-data-from-AWS.ipynb`.
    * Add `open_radar_data` for sample data sets used in unittests.
    * Add `notebook` and `nbconvert` for unittesting jupyter notebooks.
    * Add note to CONTRIBUTING.md referencing OS dependency for `ffmpeg`

- [x] Closes #253

