### PR TITLE
add nyquist_velocity as coordinate in ODIM H5/GAMIC reader

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,8 @@
 ## Development Version (unreleased)
 
 * ENH: Disable fill value in rainbow reader ({issue}`103`) ({pull}`290`) by [@egouden](https://github.com/egouden)
+* ADD: read nyquist_velocity in ODIM and GAMIC HDF5 files ({pull}`291`) by
+  [@katelbach](https://github.com/katelbach)
 
 ## 0.10.0 (2025-07-11)
 

--- a/tests/io/test_gamic.py
+++ b/tests/io/test_gamic.py
@@ -142,7 +142,7 @@ def test_open_gamic_datatree(gamic_file):
     # Verify a sample variable in one of the sweep groups
     sample_sweep = sweep_groups[0]
     assert (
-        len(dtree[sample_sweep].data_vars) == 17
+        len(dtree[sample_sweep].data_vars) == 18
     ), f"Expected data variables in {sample_sweep}"
     assert dtree[sample_sweep]["DBZH"].shape == (360, 360)
     assert (

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -534,5 +534,5 @@ def test_select_sweep_dataset_vars():
         sweep, select, ancillary=True, optional_metadata=True
     )
 
-    metadata = required_metadata + ["polarization_mode"]
+    metadata = required_metadata + ["polarization_mode", "nyquist_velocity"]
     assert sorted(sweep2.data_vars) == sorted(select + ["quality1"] + metadata)

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -246,12 +246,10 @@ class _GamicH5NetCDFMetadata(_H5NetCDFMetadata):
     @property
     def _nyquist_velocity(self):
         """Return nyquist velocity."""
-        nyquist_vel = self.how.get("nyquist_velocity", None)
-        if nyquist_vel is not None:
-            return float(nyquist_vel)
-        else:
-            pass
-        return None
+        try:
+            return float(self.how["nyquist_velocity"])
+        except (AttributeError, KeyError, TypeError):
+            return None
 
 
 class GamicStore(AbstractDataStore):

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -243,6 +243,16 @@ class _GamicH5NetCDFMetadata(_H5NetCDFMetadata):
         """Return sweep number."""
         return int(self._group.split("/")[0][4:])
 
+    @property
+    def _nyquist_velocity(self):
+        """Return nyquist velocity."""
+        nyquist_vel = self.how.get("nyquist_velocity", None)
+        if nyquist_vel is not None:
+            return float(nyquist_vel)
+        else:
+            # Return default/missing value if not found
+            return float("nan")
+
 
 class GamicStore(AbstractDataStore):
     """Store for reading ODIM dataset groups via h5netcdf."""

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -250,8 +250,8 @@ class _GamicH5NetCDFMetadata(_H5NetCDFMetadata):
         if nyquist_vel is not None:
             return float(nyquist_vel)
         else:
-            # Return default/missing value if not found
-            return float("nan")
+            pass
+        return None
 
 
 class GamicStore(AbstractDataStore):

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -484,12 +484,14 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
 
     @property
     def _nyquist_velocity(self):
-        nyquist_vel = self.how.get("NI", None)
-        if nyquist_vel is not None:
-            return float(nyquist_vel)
-        else:
-            # Return default/missing value if not found
-            return float("nan")
+        try:
+            nyquist_vel = self.how.get("NI", None)
+            if nyquist_vel is not None:
+                return float(nyquist_vel)
+        except (AttributeError, KeyError, TypeError):
+            pass
+        # Return default/missing value if not found
+        return float("nan")
 
 
 class H5NetCDFArrayWrapper(BackendArray):

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -61,6 +61,7 @@ from ...model import (
     get_elevation_attrs,
     get_latitude_attrs,
     get_longitude_attrs,
+    get_nyquist_velocity_attrs,
     get_range_attrs,
     get_time_attrs,
     moment_attrs,
@@ -257,8 +258,11 @@ class _H5NetCDFMetadata:
             "longitude": self.longitude,
             "latitude": self.latitude,
             "altitude": self.altitude,
-            "nyquist_velocity": self.nyquist_velocity,
         }
+
+        if self.nyquist_velocity is not None:
+            coordinates["nyquist_velocity"] = self.nyquist_velocity
+
         return coordinates
 
     @property
@@ -389,7 +393,7 @@ class _H5NetCDFMetadata:
 
     @property
     def nyquist_velocity(self):
-        return Variable((), self._nyquist_velocity)
+        return Variable((), self._nyquist_velocity, get_nyquist_velocity_attrs())
 
 
 class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
@@ -490,8 +494,8 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
                 return float(nyquist_vel)
         except (AttributeError, KeyError, TypeError):
             pass
-        # Return default/missing value if not found
-        return float("nan")
+
+        return None
 
 
 class H5NetCDFArrayWrapper(BackendArray):

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -257,6 +257,7 @@ class _H5NetCDFMetadata:
             "longitude": self.longitude,
             "latitude": self.latitude,
             "altitude": self.altitude,
+            "nyquist_velocity": self.nyquist_velocity,
         }
         return coordinates
 
@@ -386,6 +387,10 @@ class _H5NetCDFMetadata:
         """Return follow_mode Variable."""
         return Variable((), "not_set")
 
+    @property
+    def nyquist_velocity(self):
+        return Variable((), self._nyquist_velocity)
+
 
 class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
     """Wrapper around OdimH5 data fileobj for easy access of metadata.
@@ -476,6 +481,15 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
     @property
     def _odim_version(self):
         return self._get_odim_version()
+
+    @property
+    def _nyquist_velocity(self):
+        nyquist_vel = self.how.get("NI", None)
+        if nyquist_vel is not None:
+            return float(nyquist_vel)
+        else:
+            # Return default/missing value if not found
+            return float("nan")
 
 
 class H5NetCDFArrayWrapper(BackendArray):

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -489,13 +489,9 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
     @property
     def _nyquist_velocity(self):
         try:
-            nyquist_vel = self.how.get("NI", None)
-            if nyquist_vel is not None:
-                return float(nyquist_vel)
+            return float(self.how["NI"])
         except (AttributeError, KeyError, TypeError):
-            pass
-
-        return None
+            return None
 
 
 class H5NetCDFArrayWrapper(BackendArray):

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -34,6 +34,7 @@ __all__ = [
     "get_altitude_attrs",
     "get_elevation_attrs",
     "get_moment_attrs",
+    "get_nyquist_velocity_attrs",
     "get_range_attrs",
     "get_time_attrs",
     "moment_attrs",
@@ -725,6 +726,14 @@ def get_time_attrs(date_str="1970-01-01T00:00:00Z", date_unit="seconds"):
         "units": f"{date_unit} since {date_str}",
     }
     return time_attrs
+
+
+def get_nyquist_velocity_attrs(units="meters per second"):
+    nyquist_attrs = {
+        "standard_name": "nyquist_velocity",
+        "units": units,
+    }
+    return nyquist_attrs
 
 
 def get_moment_attrs(moment):

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -728,7 +728,7 @@ def get_time_attrs(date_str="1970-01-01T00:00:00Z", date_unit="seconds"):
     return time_attrs
 
 
-def get_nyquist_velocity_attrs(units="meters per second"):
+def get_nyquist_velocity_attrs(units="m s-1"):
     nyquist_attrs = {
         "standard_name": "nyquist_velocity",
         "units": units,


### PR DESCRIPTION
adds nyquist velocity as a coordinate when using the ODIM H5 and GAMIC backend

- [x] Tests added
- [x] Changes are documented in `history.md`
