### PR TITLE
Fix IRIS/Sigmet KDP decode

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -9,6 +9,7 @@
 * FIX: Return float32 for float types (keep other dtypes) and remove erroneous "units" from time attrs for hpl reader. ({issue}`296`) ({pull}`297`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * MNT: Fix Windows errors in file handling ({pull}`295`) by [@egouden](https://github.com/egouden)
 * MNT: do not overwrite Dataset for Dataset.update ({pull}`302`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: Properly handle zero and NaN values during IRIS/Sigmet KDP decode. ({pull}`301`) by [@billvieux](https://github.com/billvieux)
 
 ## 0.10.0 (2025-07-11)
 

--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -90,19 +90,24 @@ def test_decode_velc():
 
 def test_decode_kdp():
     np.testing.assert_array_almost_equal(
-        iris.decode_kdp(np.arange(-5, 5, dtype="int8"), wavelength=10.0),
-        [
-            12.243229,
-            12.880858,
-            13.551695,
-            14.257469,
-            15.0,
-            -0.0,
-            -15.0,
-            -14.257469,
-            -13.551695,
-            -12.880858,
-        ],
+        iris.decode_kdp(
+            np.array(
+                [
+                    0,
+                    1,
+                    2,
+                    127,
+                    -128,  # 128 uint8
+                    -127,  # 129 uint8
+                    -126,  # 130 uint8
+                    -2,  # 254 uint8
+                    -1,  # 255 uint8
+                ],
+                dtype="int8",
+            ),
+            wavelength=10.0,
+        ),
+        [np.nan, -15.0, -14.257469, -0.025, 0.0, 0.025, 0.026302, 14.257469, np.nan],
     )
 
 

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -218,7 +218,10 @@ def decode_kdp(data, **kwargs):
     See 4.4.20 p.77
     """
     wavelength = kwargs.pop("wavelength")
-    zero = data[data == -128]
+    zero = data == -128
+    not_available = (data == 0) | (data == -1)
+    data = data.astype(np.float64)
+    data[not_available] = np.nan
     data = -0.25 * np.sign(data) * 600 ** ((127 - np.abs(data)) / 126.0)
     data /= wavelength
     data[zero] = 0


### PR DESCRIPTION
Use correct mask for zero values. Use np.nan for unavailable values. Improve test coverage of special values.