### PR TITLE
use only h5netcdf and not netcdf4 to avoid conflicts

### DIFF
--- a/examples/notebooks/CfRadial1_Model_Transformation.ipynb
+++ b/examples/notebooks/CfRadial1_Model_Transformation.ipynb
@@ -57,7 +57,7 @@
    "source": [
     "## Open CfRadial1 file using xr.open_dataset\n",
     "\n",
-    "Making use of the xarray `netcdf4` backend. We get back all data and metadata in one single CfRadial1 Dataset. Since xarray 2025.04.0 we have to use `decode_timedalte=False` to prevent erroneous decoding of timedelta values for eg. pulse widths."
+    "Making use of the xarray `h5netcdf` backend. We get back all data and metadata in one single CfRadial1 Dataset. Since xarray 2025.04.0 we have to use `decode_timedalte=False` to prevent erroneous decoding of timedelta values for eg. pulse widths."
    ]
   },
   {
@@ -67,7 +67,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ds = xr.open_dataset(filename, engine=\"netcdf4\", decode_timedelta=False)\n",
+    "ds = xr.open_dataset(filename, engine=\"h5netcdf\", decode_timedelta=False)\n",
     "with xr.set_options(\n",
     "    display_expand_data_vars=True, display_expand_attrs=True, display_max_rows=1000\n",
     "):\n",

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ dask
 h5netcdf >= 1.0.0
 h5py >= 3.0.0
 lat_lon_parser
-netCDF4
 numpy
 pyproj
 scipy

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -34,9 +34,7 @@ __doc__ = __doc__.format("\n   ".join(__all__))
 
 import numpy as np
 from xarray import Dataset, DataTree, merge, open_dataset
-from xarray.backends import NetCDF4DataStore
 from xarray.backends.common import BackendEntrypoint
-from xarray.backends.store import StoreBackendEntrypoint
 
 from ... import util
 from ...model import (
@@ -328,7 +326,7 @@ def open_cfradial1_datatree(filename_or_obj, **kwargs):
     site_coords : bool
         Attach radar site-coordinates to Dataset, defaults to ``True``.
     engine: str
-        Engine that will be passed to Xarray.open_dataset, defaults to "netcdf4"
+        Engine that will be passed to xarray.open_dataset, defaults to "h5netcdf"
 
     Returns
     -------
@@ -341,12 +339,12 @@ def open_cfradial1_datatree(filename_or_obj, **kwargs):
     optional = kwargs.pop("optional", True)
     site_coords = kwargs.pop("site_coords", True)
     sweep = kwargs.pop("sweep", None)
-    engine = kwargs.pop("engine", "netcdf4")
+    engine = kwargs.pop("engine", "h5netcdf")
     # needed for new xarray literal timedelta decoding
     kwargs.update(decode_timedelta=kwargs.pop("decode_timedelta", False))
 
     # open root group, cfradial1 only has one group
-    # open_cfradial1_datatree only opens the file once using netcdf4
+    # open_cfradial1_datatree only opens the file once using h5netcdf
     # and retrieves the different groups from the loaded object
     ds = open_dataset(filename_or_obj, engine=engine, **kwargs)
 
@@ -396,7 +394,7 @@ class CfRadial1BackendEntrypoint(BackendEntrypoint):
         Additional kwargs are fed to :py:func:`xarray.open_dataset`.
     """
 
-    description = "Open CfRadial1 (.nc, .nc4) using netCDF4 in Xarray"
+    description = "Open CfRadial1 (.nc, .nc4) using h5netcdf in xarray"
     url = "https://xradar.rtfd.io/en/latest/io.html#cfradial1"
 
     def open_dataset(
@@ -418,16 +416,10 @@ class CfRadial1BackendEntrypoint(BackendEntrypoint):
         site_coords=True,
         optional=True,
     ):
-        store = NetCDF4DataStore.open(
+        # Open using h5netcdf engine and then construct the CfRadial1 view
+        ds0 = open_dataset(
             filename_or_obj,
-            format=format,
-            group=None,
-        )
-
-        store_entrypoint = StoreBackendEntrypoint()
-
-        ds0 = store_entrypoint.open_dataset(
-            store,
+            engine="h5netcdf",
             mask_and_scale=mask_and_scale,
             decode_times=decode_times,
             concat_characters=concat_characters,

--- a/xradar/io/export/cfradial1.py
+++ b/xradar/io/export/cfradial1.py
@@ -328,4 +328,5 @@ def to_cfradial1(dtree=None, filename=None, calibs=True):
         time = str(dataset.time[0].dt.strftime("%Y%m%d_%H%M%S").values)
         filename = f"cfrad1_{dataset.instrument_name}_{time}.nc"
 
-    dataset.to_netcdf(filename, format="netcdf4")
+    # Write using h5netcdf backend to avoid netCDF4 dependency
+    dataset.to_netcdf(filename, engine="h5netcdf")


### PR DESCRIPTION
This is a pragmatic solution to the infamous shared HDF5 library issue.

The specific changes are proposed by Junie and might need further review. 