### PR TITLE
use dtype with fallback

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -4,6 +4,7 @@
 ## Development version (unreleased)
 
 * MNT: Pre-commit update + lint ({pull}`325`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
+* FIX: Use ``dtype`` with fallback in odim export ({pull}`324`) by [@katelbach](https://github.com/katelbach)
 
 ## 0.11.0 (2026-01-12)
 

--- a/xradar/io/export/odim.py
+++ b/xradar/io/export/odim.py
@@ -122,7 +122,7 @@ def _write_odim_dataspace(source, destination, compression, compression_opts):
             fillvalue=_fillvalue,
             dtype=dtype,
         )
-        if enc["dtype"] == "uint8":
+        if dtype == "uint8":
             image = "IMAGE"
             version = "1.2"
             tid1 = h5py.h5t.C_S1.copy()


### PR DESCRIPTION
Minor fix as I noted that ODIM H5 exports fail because the fallback value for dtype is not used in an if query.

- [ ] Tests added
- [x] Changes are documented in `history.md`
