### PR TITLE
ENH: move station coords to root and add optional_groups parameter

### DIFF
--- a/docs/datamodel.md
+++ b/docs/datamodel.md
@@ -17,6 +17,7 @@ This group holds data and metadata relevant to the entire volume. These are:
 
 - attributes
 - ancillary variables
+- station coordinates (``latitude``, ``longitude``, ``altitude``) — placed as coordinates on the root node so that sweep child nodes can inherit them via DataTree coordinate inheritance
 
 Internal representation: {py:class}`xarray:xarray.Dataset`
 

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,6 +1,11 @@
 # History
 
 
+## Development
+
+* ENH: Move station coordinates (``latitude``, ``longitude``, ``altitude``) to root node as coordinates for DataTree coordinate inheritance ({issue}`331`) by [@aladinor](https://github.com/aladinor)
+* ENH: Add ``optional_groups`` parameter (default ``False``) to all ``open_*_datatree()`` functions to control inclusion of ``/radar_parameters``, ``/georeferencing_correction``, and ``/radar_calibration`` subgroups ({issue}`331`) by [@aladinor](https://github.com/aladinor)
+
 ## 0.11.1 (2026-02-03)
 
 * MNT: Pre-commit update + lint ({pull}`325`) by [@kmuehlbauer](https://github.com/kmuehlbauer)

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -2,6 +2,37 @@
 
 The backends use different approaches to ingest the data.
 
+## Common DataTree behavior
+
+All ``open_*_datatree()`` functions share the following behavior:
+
+### Station coordinates
+
+Station location variables (``latitude``, ``longitude``, ``altitude``) are placed as
+**coordinates** on the root node of the {py:class}`xarray:xarray.DataTree`. Sweep child
+nodes do not carry their own copies of these variables — they are designed to inherit
+them from root via DataTree coordinate inheritance.
+
+When opening a single sweep with {py:func}`xarray.open_dataset` and ``site_coords=True``
+(the default), station coordinates are still attached directly to the returned
+{py:class}`xarray:xarray.Dataset`.
+
+### Optional metadata subgroups
+
+By default, the metadata subgroups ``/radar_parameters``, ``/georeferencing_correction``,
+and ``/radar_calibration`` are **not** included in the DataTree. Pass
+``optional_groups=True`` to include them:
+
+```python
+import xradar as xd
+
+# Default: lean DataTree without metadata subgroups
+dtree = xd.io.open_nexradlevel2_datatree(filename)
+
+# Include optional metadata subgroups
+dtree = xd.io.open_nexradlevel2_datatree(filename, optional_groups=True)
+```
+
 ## CfRadial1
 
 ### CfRadial1BackendEntrypoint

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -9,13 +9,12 @@ All ``open_*_datatree()`` functions share the following behavior:
 ### Station coordinates
 
 Station location variables (``latitude``, ``longitude``, ``altitude``) are placed as
-**coordinates** on the root node of the {py:class}`xarray:xarray.DataTree`. Sweep child
-nodes do not carry their own copies of these variables — they are designed to inherit
-them from root via DataTree coordinate inheritance.
-
-When opening a single sweep with {py:func}`xarray.open_dataset` and ``site_coords=True``
-(the default), station coordinates are still attached directly to the returned
-{py:class}`xarray:xarray.Dataset`.
+**coordinates** on the root node of the {py:class}`xarray:xarray.DataTree`, following
+CfRadial 2.0 Section 4.4. Sweep child nodes also retain local copies of these variables
+for compatibility with code that accesses them directly on sweep datasets (e.g.
+georeferencing). Once xarray supports scalar coordinate inheritance
+(`pydata/xarray#9077 <https://github.com/pydata/xarray/issues/9077>`_), the sweep-level
+copies can be removed in a future release.
 
 ### Optional metadata subgroups
 

--- a/examples/notebooks/CfRadial1_Model_Transformation.ipynb
+++ b/examples/notebooks/CfRadial1_Model_Transformation.ipynb
@@ -404,7 +404,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtree = xd.io.open_cfradial1_datatree(filename)\n",
+    "dtree = xd.io.open_cfradial1_datatree(filename, optional_groups=True)\n",
     "with xr.set_options(display_expand_data_vars=True, display_expand_attrs=True):\n",
     "    display(dtree)"
    ]
@@ -506,7 +506,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dtree3 = xd.io.open_cfradial1_datatree(filename)"
+    "dtree3 = xd.io.open_cfradial1_datatree(filename, optional_groups=True)"
    ]
   },
   {

--- a/tests/io/test_datamet.py
+++ b/tests/io/test_datamet.py
@@ -98,16 +98,12 @@ def test_open_datamet_datatree(datamet_file):
     dtree = open_datamet_datatree(datamet_file, **kwargs)
 
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -126,16 +122,16 @@ def test_open_datamet_datatree(datamet_file):
         "VRADH" in dtree[sample_sweep].data_vars
     ), f"VRADH should be a data variable in {sample_sweep}"
 
-    # Validate coordinates are attached correctly in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 10

--- a/tests/io/test_datamet.py
+++ b/tests/io/test_datamet.py
@@ -139,3 +139,11 @@ def test_open_datamet_datatree(datamet_file):
     ), "Scan name should match expected value"
 
     # Verify a sample variable in on
+
+
+def test_open_datamet_datatree_optional_groups(datamet_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_datamet_datatree(datamet_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_datamet.py
+++ b/tests/io/test_datamet.py
@@ -128,11 +128,6 @@ def test_open_datamet_datatree(datamet_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 10
     assert (

--- a/tests/io/test_furuno.py
+++ b/tests/io/test_furuno.py
@@ -644,16 +644,12 @@ def test_open_furuno_datatree(furuno_scn_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -668,17 +664,17 @@ def test_open_furuno_datatree(furuno_scn_file):
         "VRADH" in dtree[sample_sweep].data_vars
     ), f"VRADH should be a data variable in {sample_sweep}"
 
-    # Validate coordinates are attached correctly
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
-    assert len(dtree[sample_sweep].variables) == 21
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
+    assert len(dtree[sample_sweep].variables) == 18
     assert dtree[sample_sweep]["DBZH"].shape == (360, 602)
     assert len(dtree.attrs) == 9
     assert dtree.attrs["version"] == 3

--- a/tests/io/test_furuno.py
+++ b/tests/io/test_furuno.py
@@ -675,3 +675,11 @@ def test_open_furuno_datatree(furuno_scn_file):
     assert len(dtree.attrs) == 9
     assert dtree.attrs["version"] == 3
     assert dtree.attrs["source"] == "Furuno"
+
+
+def test_open_furuno_datatree_optional_groups(furuno_scn_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_furuno_datatree(furuno_scn_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_furuno.py
+++ b/tests/io/test_furuno.py
@@ -670,11 +670,7 @@ def test_open_furuno_datatree(furuno_scn_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-    assert len(dtree[sample_sweep].variables) == 18
+    assert len(dtree[sample_sweep].variables) == 21
     assert dtree[sample_sweep]["DBZH"].shape == (360, 602)
     assert len(dtree.attrs) == 9
     assert dtree.attrs["version"] == 3

--- a/tests/io/test_gamic.py
+++ b/tests/io/test_gamic.py
@@ -173,11 +173,6 @@ def test_open_gamic_datatree(gamic_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 9
     assert dtree.attrs["source"] == "gamic", "Source should match expected value"

--- a/tests/io/test_gamic.py
+++ b/tests/io/test_gamic.py
@@ -143,16 +143,12 @@ def test_open_gamic_datatree(gamic_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -171,16 +167,16 @@ def test_open_gamic_datatree(gamic_file):
         "VRADV" in dtree[sample_sweep].data_vars
     ), f"VRADV should be a data variable in {sample_sweep}"
 
-    # Validate coordinates are attached correctly in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_gamic.py
+++ b/tests/io/test_gamic.py
@@ -176,3 +176,11 @@ def test_open_gamic_datatree(gamic_file):
     # Validate attributes
     assert len(dtree.attrs) == 9
     assert dtree.attrs["source"] == "gamic", "Source should match expected value"
+
+
+def test_open_gamic_datatree_optional_groups(gamic_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_gamic_datatree(gamic_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -126,9 +126,5 @@ def test_open_hpl_datatree():
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_hpl.py
+++ b/tests/io/test_hpl.py
@@ -128,3 +128,14 @@ def test_open_hpl_datatree():
 
     # Validate attributes
     assert len(dtree.attrs) == 9
+
+
+def test_open_hpl_datatree_optional_groups():
+    """Test that optional_groups=True includes metadata subgroups."""
+    from open_radar_data import DATASETS
+
+    hpl_file = DATASETS.fetch("User1_184_20240601_013257.hpl")
+    dtree = xd.io.open_hpl_datatree(hpl_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -52,9 +52,11 @@ def test_open_cfradial1_datatree(cfradial1_file):
     assert rvars["instrument_type"] == b"radar"
     assert rvars["time_coverage_start"] == b"2008-06-04T00:15:03Z"
     assert rvars["time_coverage_end"] == b"2008-06-04T00:22:17Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(22.526699))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(120.4335022))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(45.0000018))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(22.526699))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(120.4335022))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(45.0000018))
 
     # iterate over subgroups and check some values
     moments = ["DBZ", "VR"]
@@ -126,9 +128,11 @@ def test_open_odim_datatree(odim_file):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2018-12-20T06:06:28Z"
     assert rvars["time_coverage_end"] == "2018-12-20T06:10:42Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(-33.7008018))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(151.2089996))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(195.0))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(-33.7008018))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(151.2089996))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(195.0))
 
     # iterate over subgroups and check some values
     moments = ["PHIDP", "VRADH", "DBZH", "TH", "ZDR", "RHOHV", "WRADH", "KDP"]
@@ -178,9 +182,6 @@ def test_open_odim_datatree(odim_file):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -276,9 +277,11 @@ def test_open_gamic_datatree(gamic_file):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2018-06-01T05:40:47Z"
     assert rvars["time_coverage_end"] == "2018-06-01T05:44:16Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(50.9287272))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(6.4569489))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(310.0))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(50.9287272))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(6.4569489))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(310.0))
 
     # iterate over subgroups and check some values
     moments = [
@@ -333,9 +336,6 @@ def test_open_gamic_datatree(gamic_file):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -520,9 +520,11 @@ def test_open_rainbow_datatree(rainbow_file):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2013-05-10T00:00:06Z"
     assert rvars["time_coverage_end"] == "2013-05-10T00:03:14Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(50.856633))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(6.379967))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(116.7))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(50.856633))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(6.379967))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(116.7))
 
     # iterate over subgroups and check some values
     moments = [
@@ -559,9 +561,6 @@ def test_open_rainbow_datatree(rainbow_file):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -614,9 +613,11 @@ def test_open_iris_datatree(iris0_file):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2013-11-25T10:55:04Z"
     assert rvars["time_coverage_end"] == "2013-11-25T10:59:24Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(9.331))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(-75.2829999))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(143.0))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(9.331))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(-75.2829999))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(143.0))
 
     # iterate over subgroups and check some values
     moments = [
@@ -655,9 +656,6 @@ def test_open_iris_datatree(iris0_file):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -867,9 +865,11 @@ def test_open_datamet_datatree(datamet_file):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2019-07-10T07:00:00Z"
     assert rvars["time_coverage_end"] == "2019-07-10T07:00:00Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(41.9394))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(14.6208))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(710))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(41.9394))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(14.6208))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(710))
 
     # iterate over subgroups and check some values
     moments = ["DBTH", "DBZH", "KDP", "PHIDP", "RHOHV", "VRADH", "WRADH", "ZDR"]
@@ -890,9 +890,6 @@ def test_open_datamet_datatree(datamet_file):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.isclose(ds.elevation.mean().values.item(), elevations[i], atol=0.05)
@@ -901,11 +898,11 @@ def test_open_datamet_datatree(datamet_file):
 
     # Try to reed single sweep
     dtree = open_datamet_datatree(datamet_file, sweep=1)
-    assert len(dtree.groups) == 5
+    assert len(dtree.groups) == 2
 
     # Try to read list of sweeps
     dtree = open_datamet_datatree(datamet_file, sweep=[1, 2])
-    assert len(dtree.groups) == 6
+    assert len(dtree.groups) == 3
 
 
 @pytest.mark.parametrize("first_dim", ["time", "auto"])
@@ -952,9 +949,11 @@ def test_cfradial_n_points_file(cfradial1n_file):
     assert rvars["instrument_type"] == b"radar"
     assert rvars["time_coverage_start"] == b"2024-05-22T16:00:47Z"
     assert rvars["time_coverage_end"] == b"2024-05-22T16:03:20Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(45.6272661))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(9.1963181))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(241.0))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(45.6272661))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(9.1963181))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(241.0))
 
     # iterate over subgroups and check some values
     moments = ["ZDR", "RHOHV", "KDP", "DBZ", "VEL", "PHIDP"]
@@ -1021,9 +1020,11 @@ def test_open_nexradlevel2_datatree(nexradlevel2_files):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2016-06-01T15:00:25Z"
     assert rvars["time_coverage_end"] == "2016-06-01T15:06:06Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(33.65414047))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(-101.81416321))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(1029))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(33.65414047))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(-101.81416321))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(1029))
 
     # iterate over subgroups and check some values
     moments = [
@@ -1078,7 +1079,7 @@ def test_open_nexradlevel2_datatree(nexradlevel2_files):
         308,
         232,
     ]
-    assert len(dtree.groups[1:]) == 14
+    assert len(dtree.groups[1:]) == 11
     for i, grp in enumerate(dtree.match("sweep_*")):
         print(i)
         ds = dtree[grp].ds
@@ -1093,9 +1094,6 @@ def test_open_nexradlevel2_datatree(nexradlevel2_files):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -1147,9 +1145,11 @@ def test_open_uf_datatree(uf_file_1):
     assert rvars["instrument_type"] == "radar"
     assert rvars["time_coverage_start"] == "2011-04-27T16:42:32Z"
     assert rvars["time_coverage_end"] == "2011-04-27T16:46:50Z"
-    np.testing.assert_almost_equal(rvars["latitude"].values, np.array(34.9318099))
-    np.testing.assert_almost_equal(rvars["longitude"].values, np.array(-86.4658203))
-    np.testing.assert_almost_equal(rvars["altitude"].values, np.array(226))
+    # station coords are now coordinates on root, not data_vars
+    rcoords = dtree.ds.coords
+    np.testing.assert_almost_equal(rcoords["latitude"].values, np.array(34.9318099))
+    np.testing.assert_almost_equal(rcoords["longitude"].values, np.array(-86.4658203))
+    np.testing.assert_almost_equal(rcoords["altitude"].values, np.array(226))
 
     # iterate over subgroups and check some values
     moments = [
@@ -1216,7 +1216,7 @@ def test_open_uf_datatree(uf_file_1):
         476,
         422,
     ]
-    assert len(dtree.groups[1:]) == 17
+    assert len(dtree.groups[1:]) == 14
     for i, grp in enumerate(dtree.match("sweep_*")):
         print(i)
         ds = dtree[grp].ds
@@ -1231,9 +1231,6 @@ def test_open_uf_datatree(uf_file_1):
             "azimuth",
             "elevation",
             "time",
-            "latitude",
-            "longitude",
-            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]

--- a/tests/io/test_io.py
+++ b/tests/io/test_io.py
@@ -182,6 +182,9 @@ def test_open_odim_datatree(odim_file):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -336,6 +339,9 @@ def test_open_gamic_datatree(gamic_file):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -561,6 +567,9 @@ def test_open_rainbow_datatree(rainbow_file):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -656,6 +665,9 @@ def test_open_iris_datatree(iris0_file):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -890,6 +902,9 @@ def test_open_datamet_datatree(datamet_file):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.isclose(ds.elevation.mean().values.item(), elevations[i], atol=0.05)
@@ -1094,6 +1109,9 @@ def test_open_nexradlevel2_datatree(nexradlevel2_files):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]
@@ -1231,6 +1249,9 @@ def test_open_uf_datatree(uf_file_1):
             "azimuth",
             "elevation",
             "time",
+            "latitude",
+            "longitude",
+            "altitude",
             "range",
         }
         assert np.round(ds.elevation.mean().values.item(), 1) == elevations[i]

--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -372,3 +372,11 @@ def test_open_iris_datatree(iris0_file):
         dtree.attrs["instrument_name"] == "Corozal, Radar"
     ), "Instrument name should match expected value"
     assert dtree.attrs["source"] == "Sigmet", "Source should match expected value"
+
+
+def test_open_iris_datatree_optional_groups(iris0_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_iris_datatree(iris0_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -336,16 +336,12 @@ def test_open_iris_datatree(iris0_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -364,16 +360,16 @@ def test_open_iris_datatree(iris0_file):
         "VRADH" in dtree[sample_sweep].data_vars
     ), f"VRADH should be a data variable in {sample_sweep}"
 
-    # Validate coordinates are attached correctly in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 10

--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -366,11 +366,6 @@ def test_open_iris_datatree(iris0_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 10
     assert (

--- a/tests/io/test_metek.py
+++ b/tests/io/test_metek.py
@@ -326,3 +326,11 @@ def test_open_metek_datatree(metek_pro_gz_file):
 
     # Validate attributes
     assert len(dtree.attrs) == 9
+
+
+def test_open_metek_datatree_optional_groups(metek_pro_gz_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_metek_datatree(metek_pro_gz_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_metek.py
+++ b/tests/io/test_metek.py
@@ -324,10 +324,5 @@ def test_open_metek_datatree(metek_pro_gz_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_metek.py
+++ b/tests/io/test_metek.py
@@ -297,16 +297,12 @@ def test_open_metek_datatree(metek_pro_gz_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Verify that sweep group is attached correctly (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -322,16 +318,16 @@ def test_open_metek_datatree(metek_pro_gz_file):
     ), "Expected 'velocity' variable in the sweep group"
     np.testing.assert_allclose(dtree[sample_sweep]["reflectivity"].values[0], test_arr)
 
-    # Validate coordinates in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -561,16 +561,13 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -586,16 +583,17 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
         "ZDR" in dtree[sample_sweep].data_vars
     ), f"VRADH should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBZH"].shape == (360, 1832)
-    # Validate coordinates are attached correctly
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "KATX"
@@ -622,16 +620,13 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -644,20 +639,48 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
         "DBZH" in dtree[sample_sweep].data_vars
     ), f"DBZH should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBZH"].shape == (360, 460)
-    # Validate coordinates are attached correctly
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+
+    # Station coords should be on root as coordinates
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "KLIX"
     assert dtree.attrs["scan_name"] == "VCP-0"
+
+
+def test_open_nexradlevel2_datatree_optional_groups(nexradlevel2_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_nexradlevel2_datatree(
+        nexradlevel2_file, sweep=[0], optional_groups=True
+    )
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children
+
+    # Station coords should still be on root as coordinates
+    assert "latitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+
+def test_open_nexradlevel2_single_dataset_site_coords(nexradlevel2_file):
+    """Single-dataset access via open_dataset still has lat/lon/alt with site_coords=True."""
+    ds = xarray.open_dataset(
+        nexradlevel2_file,
+        engine=NexradLevel2BackendEntrypoint,
+        group="sweep_0",
+        site_coords=True,
+    )
+    assert "latitude" in ds.coords
+    assert "longitude" in ds.coords
+    assert "altitude" in ds.coords
 
 
 @pytest.mark.parametrize(

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -584,16 +584,11 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
     ), f"VRADH should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBZH"].shape == (360, 1832)
 
-    # Station coords should be on root as coordinates, NOT on sweeps
+    # Station coords should be on root as coordinates
     assert "latitude" in dtree.ds.coords
     assert "longitude" in dtree.ds.coords
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
-
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "KATX"
@@ -645,11 +640,6 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
     assert "longitude" in dtree.ds.coords
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
-
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "KLIX"

--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -221,11 +221,6 @@ def test_open_odim_datatree(odim_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 9
     assert (

--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -226,3 +226,11 @@ def test_open_odim_datatree(odim_file):
     assert (
         dtree.attrs["Conventions"] == "ODIM_H5/V2_2"
     ), "Instrument name should match expected value"
+
+
+def test_open_odim_datatree_optional_groups(odim_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_odim_datatree(odim_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -192,16 +192,12 @@ def test_open_odim_datatree(odim_file):
 
     # Assertions to check DataTree structure
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if the correct sweep groups are attached
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -219,16 +215,16 @@ def test_open_odim_datatree(odim_file):
         360,
         1200,
     ), "Shape mismatch for 'DBZH' variable"
-    # Validate coordinates in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_rainbow.py
+++ b/tests/io/test_rainbow.py
@@ -222,16 +222,12 @@ def test_open_rainbow_datatree(rainbow_file):
 
     # Assertions to check DataTree structure
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if the specified sweep groups are attached
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -247,16 +243,16 @@ def test_open_rainbow_datatree(rainbow_file):
         400,
     ), "Shape mismatch for 'DBZH' variable"
 
-    # Validate coordinates are attached correctly in the root dataset
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_rainbow.py
+++ b/tests/io/test_rainbow.py
@@ -251,3 +251,11 @@ def test_open_rainbow_datatree(rainbow_file):
 
     # Validate attributes
     assert len(dtree.attrs) == 9
+
+
+def test_open_rainbow_datatree_optional_groups(rainbow_file):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_rainbow_datatree(rainbow_file, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children

--- a/tests/io/test_rainbow.py
+++ b/tests/io/test_rainbow.py
@@ -249,10 +249,5 @@ def test_open_rainbow_datatree(rainbow_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     # Validate attributes
     assert len(dtree.attrs) == 9

--- a/tests/io/test_uf.py
+++ b/tests/io/test_uf.py
@@ -383,6 +383,14 @@ def test_open_uf_with_bytes(uf_file_3):
         assert fh.ray_headers[1][0]["mhead"]["SweepMode"] == 3
 
 
+def test_open_uf_datatree_optional_groups(uf_file_1):
+    """Test that optional_groups=True includes metadata subgroups."""
+    dtree = open_uf_datatree(uf_file_1, optional_groups=True)
+    assert "radar_parameters" in dtree.children
+    assert "georeferencing_correction" in dtree.children
+    assert "radar_calibration" in dtree.children
+
+
 def test_uf_unsupported_input_type():
     unsupported_input = 12345  # int is not supported
     with pytest.raises(TypeError, match="Unsupported input type: <class 'int'>"):

--- a/tests/io/test_uf.py
+++ b/tests/io/test_uf.py
@@ -254,11 +254,6 @@ def test_open_uf_datatree(uf_file_1):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
-
     assert len(dtree.attrs) == 10
     print(dtree.attrs)
     assert dtree.attrs["instrument_name"] == "rvp8-rel"
@@ -305,16 +300,11 @@ def test_open_uf_datatree_2(uf_file_2):
     ), f"DBTH should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBTH"].shape == (360, 476)
 
-    # Station coords should be on root as coordinates, NOT on sweeps
+    # Station coords should be on root as coordinates
     assert "latitude" in dtree.ds.coords
     assert "longitude" in dtree.ds.coords
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
-
-    # Sweeps should NOT have local station coords
-    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
-    assert "latitude" not in sweep_ds.coords
-    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "CHILL"

--- a/tests/io/test_uf.py
+++ b/tests/io/test_uf.py
@@ -225,16 +225,13 @@ def test_open_uf_datatree(uf_file_1):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -250,16 +247,17 @@ def test_open_uf_datatree(uf_file_1):
         "ZDR" in dtree[sample_sweep].data_vars
     ), f"ZDR should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBTH"].shape == (360, 997)
-    # Validate coordinates are attached correctly
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     print(dtree.attrs)
@@ -287,16 +285,13 @@ def test_open_uf_datatree_2(uf_file_2):
 
     # Assertions
     assert isinstance(dtree, DataTree), "Expected a DataTree instance"
-    assert "/" in dtree.subtree, "Root group should be present in the DataTree"
-    assert (
-        "/radar_parameters" in dtree.subtree
-    ), "Radar parameters group should be in the DataTree"
-    assert (
-        "/georeferencing_correction" in dtree.subtree
-    ), "Georeferencing correction group should be in the DataTree"
-    assert (
-        "/radar_calibration" in dtree.subtree
-    ), "Radar calibration group should be in the DataTree"
+    subtree_paths = [n.path for n in dtree.subtree]
+    assert "/" in subtree_paths, "Root group should be present in the DataTree"
+
+    # optional_groups=False by default: metadata subgroups should NOT be present
+    assert "radar_parameters" not in dtree.children
+    assert "georeferencing_correction" not in dtree.children
+    assert "radar_calibration" not in dtree.children
 
     # Check if at least one sweep group is attached (e.g., "/sweep_0")
     sweep_groups = [key for key in dtree.match("sweep_*")]
@@ -309,16 +304,17 @@ def test_open_uf_datatree_2(uf_file_2):
         "DBTH" in dtree[sample_sweep].data_vars
     ), f"DBTH should be a data variable in {sample_sweep}"
     assert dtree[sample_sweep]["DBTH"].shape == (360, 476)
-    # Validate coordinates are attached correctly
-    assert (
-        "latitude" in dtree[sample_sweep]
-    ), "Latitude should be attached to the root dataset"
-    assert (
-        "longitude" in dtree[sample_sweep]
-    ), "Longitude should be attached to the root dataset"
-    assert (
-        "altitude" in dtree[sample_sweep]
-    ), "Altitude should be attached to the root dataset"
+
+    # Station coords should be on root as coordinates, NOT on sweeps
+    assert "latitude" in dtree.ds.coords
+    assert "longitude" in dtree.ds.coords
+    assert "altitude" in dtree.ds.coords
+    assert "latitude" not in dtree.ds.data_vars
+
+    # Sweeps should NOT have local station coords
+    sweep_ds = dtree[sample_sweep].to_dataset(inherit=False)
+    assert "latitude" not in sweep_ds.coords
+    assert "latitude" not in sweep_ds.data_vars
 
     assert len(dtree.attrs) == 10
     assert dtree.attrs["instrument_name"] == "CHILL"

--- a/tests/test_accessors.py
+++ b/tests/test_accessors.py
@@ -215,7 +215,7 @@ def test_accessor_to_cfradial1():
 def test_accessor_to_cfradial2():
     """Test the accessor function to convert CfRadial1 Dataset back to DataTree."""
     file = DATASETS.fetch("cfrad.20080604_002217_000_SPOL_v36_SUR.nc")
-    dtree = xd.io.open_cfradial1_datatree(file)
+    dtree = xd.io.open_cfradial1_datatree(file, optional_groups=True)
 
     # Convert to CfRadial1 dataset
     ds_cf1 = dtree.xradar.to_cfradial1_dataset()

--- a/tests/transform/test_cfradial.py
+++ b/tests/transform/test_cfradial.py
@@ -29,7 +29,7 @@ def test_to_cfradial1(cfradial1_file):
 
 def test_to_cfradial2(cfradial1_file):
     """Test the conversion from CfRadial1 to CfRadial2 DataTree format."""
-    with xd.io.open_cfradial1_datatree(cfradial1_file) as dtree:
+    with xd.io.open_cfradial1_datatree(cfradial1_file, optional_groups=True) as dtree:
 
         # Convert to CfRadial1 dataset first
         ds_cf1 = xd.transform.to_cfradial1(dtree)

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -362,6 +362,7 @@ def open_cfradial1_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     first_dim = kwargs.pop("first_dim", "auto")
     optional = kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     site_coords = kwargs.pop("site_coords", True)
     sweep = kwargs.pop("sweep", None)
     engine = kwargs.pop("engine", "netcdf4")
@@ -376,12 +377,13 @@ def open_cfradial1_datatree(filename_or_obj, **kwargs):
     # create datatree root node additional root metadata groups
     dtree: dict = {
         "/": _get_required_root_dataset(ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ds),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(ds)
 
     # radar_calibration (connected with calib-dimension)
     dtree = _attach_sweep_groups(

--- a/xradar/io/backends/cfradial1.py
+++ b/xradar/io/backends/cfradial1.py
@@ -49,7 +49,7 @@ from ...model import (
     required_global_attrs,
     required_root_vars,
 )
-from .common import _attach_sweep_groups, _maybe_decode
+from .common import _STATION_VARS, _attach_sweep_groups, _maybe_decode
 
 
 def _get_required_root_dataset(ds, optional=True):
@@ -89,6 +89,12 @@ def _get_required_root_dataset(ds, optional=True):
     root.sweep_group_name.encoding["dtype"] = root.sweep_group_name.dtype
     # remove cf standard name
     root.sweep_group_name.attrs = []
+
+    # Promote station location to coordinates on the root node.
+    promote = _STATION_VARS & set(root.data_vars)
+    if promote:
+        root = root.set_coords(list(promote))
+
     return root
 
 

--- a/xradar/io/backends/common.py
+++ b/xradar/io/backends/common.py
@@ -66,27 +66,9 @@ _STATION_VARS = {"latitude", "longitude", "altitude"}
 def _attach_sweep_groups(dtree, sweeps):
     """Attach sweep groups to DataTree."""
     for i, sw in enumerate(sweeps):
-        # Remove station coords — they live on the root node and are
-        # inherited by sweep children via DataTree coordinate inheritance.
-        to_drop = _STATION_VARS & (set(sw.coords) | set(sw.data_vars))
-        if to_drop:
-            sw = sw.drop_vars(to_drop)
         # remove attributes only from Dataset's not DataArrays
         dtree[f"sweep_{i}"] = xr.DataTree(sw.drop_attrs(deep=False))
     return dtree
-
-
-def _remove_sweep_station_coords(sweep_dict):
-    """Remove station coords from a sweep dict (they inherit from root).
-
-    Used by backends that build a ``{"/sweep_0": ds, ...}`` dict directly
-    instead of going through :func:`_attach_sweep_groups`.
-    """
-    for key, ds in sweep_dict.items():
-        to_drop = _STATION_VARS & (set(ds.coords) | set(ds.data_vars))
-        if to_drop:
-            sweep_dict[key] = ds.drop_vars(to_drop)
-    return sweep_dict
 
 
 def _get_h5group_names(filename, engine):

--- a/xradar/io/backends/datamet.py
+++ b/xradar/io/backends/datamet.py
@@ -493,6 +493,7 @@ def open_datamet_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     kwargs["backend_kwargs"] = backend_kwargs
 
     sweep = kwargs.pop("sweep", None)
@@ -524,11 +525,14 @@ def open_datamet_datatree(filename_or_obj, **kwargs):
 
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/furuno.py
+++ b/xradar/io/backends/furuno.py
@@ -822,17 +822,21 @@ def open_furuno_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     kwargs["backend_kwargs"] = backend_kwargs
 
     ls_ds = [xr.open_dataset(filename_or_obj, engine="furuno", **kwargs)]
 
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/gamic.py
+++ b/xradar/io/backends/gamic.py
@@ -535,6 +535,7 @@ def open_gamic_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("Optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -558,11 +559,14 @@ def open_gamic_datatree(filename_or_obj, **kwargs):
 
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/hpl.py
+++ b/xradar/io/backends/hpl.py
@@ -635,6 +635,7 @@ def open_hpl_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("optional", None)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -660,11 +661,14 @@ def open_hpl_datatree(filename_or_obj, **kwargs):
         "/": _get_required_root_dataset(ls_ds, optional=optional).rename(
             {"sweep_fixed_angle": "fixed_angle"}
         ),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -4111,6 +4111,7 @@ def open_iris_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -4133,11 +4134,14 @@ def open_iris_datatree(filename_or_obj, **kwargs):
     ]
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/metek.py
+++ b/xradar/io/backends/metek.py
@@ -667,6 +667,7 @@ def open_metek_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -689,11 +690,14 @@ def open_metek_datatree(filename_or_obj, **kwargs):
     ].copy()
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -57,7 +57,6 @@ from xradar.io.backends.common import (
     _assign_root,
     _get_radar_calibration,
     _get_subgroup,
-    _remove_sweep_station_coords,
 )
 from xradar.model import (
     georeferencing_correction_subgroup,
@@ -1812,7 +1811,6 @@ def open_nexradlevel2_datatree(
         sweep_path: sweep_dict[sweep_path].drop_attrs(deep=False)
         for sweep_path in sweep_dict.keys()
     }
-    sweep_dict = _remove_sweep_station_coords(sweep_dict)
     dtree = dtree | sweep_dict
     return DataTree.from_dict(dtree)
 

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -917,6 +917,7 @@ def open_odim_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -940,11 +941,14 @@ def open_odim_datatree(filename_or_obj, **kwargs):
     # todo: apply CfRadial2 group structure below
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/rainbow.py
+++ b/xradar/io/backends/rainbow.py
@@ -916,6 +916,7 @@ def open_rainbow_datatree(filename_or_obj, **kwargs):
     # handle kwargs, extract first_dim
     backend_kwargs = kwargs.pop("backend_kwargs", {})
     optional = backend_kwargs.pop("optional", True)
+    optional_groups = kwargs.pop("optional_groups", False)
     sweep = kwargs.pop("sweep", None)
     sweeps = []
     kwargs["backend_kwargs"] = backend_kwargs
@@ -939,11 +940,14 @@ def open_rainbow_datatree(filename_or_obj, **kwargs):
 
     dtree: dict = {
         "/": _get_required_root_dataset(ls_ds, optional=optional),
-        "/radar_parameters": _get_subgroup(ls_ds, radar_parameters_subgroup),
-        "/georeferencing_correction": _get_subgroup(
-            ls_ds, georeferencing_correction_subgroup
-        ),
-        "/radar_calibration": _get_radar_calibration(ls_ds, radar_calibration_subgroup),
     }
+    if optional_groups:
+        dtree["/radar_parameters"] = _get_subgroup(ls_ds, radar_parameters_subgroup)
+        dtree["/georeferencing_correction"] = _get_subgroup(
+            ls_ds, georeferencing_correction_subgroup
+        )
+        dtree["/radar_calibration"] = _get_radar_calibration(
+            ls_ds, radar_calibration_subgroup
+        )
     dtree = _attach_sweep_groups(dtree, ls_ds)
     return DataTree.from_dict(dtree)

--- a/xradar/io/backends/uf.py
+++ b/xradar/io/backends/uf.py
@@ -48,7 +48,6 @@ from xradar.io.backends.common import (
     _assign_root,
     _get_radar_calibration,
     _get_subgroup,
-    _remove_sweep_station_coords,
 )
 from xradar.model import (
     georeferencing_correction_subgroup,
@@ -968,7 +967,6 @@ def open_uf_datatree(
         sweep_path: sweep_dict[sweep_path].drop_attrs(deep=False)
         for sweep_path in sweep_dict.keys()
     }
-    sweep_dict = _remove_sweep_station_coords(sweep_dict)
     dtree = dtree | sweep_dict
     return xr.DataTree.from_dict(dtree)
 


### PR DESCRIPTION
## Summary

Closes #331

- Promote station coordinates (`latitude`, `longitude`, `altitude`) to **coordinates on the root node**, aligning with CfRadial 2.0 Section 4.4. Station coords remain on sweeps for backward compatibility since xarray does not yet support scalar coordinate inheritance ([pydata/xarray#9077](https://github.com/pydata/xarray/issues/9077)). Once xarray adds this, a follow-up PR can remove sweep-level copies.
- Add `optional_groups` parameter (default `False`) to all 11 `open_*_datatree()` functions, controlling inclusion of `/radar_parameters`, `/georeferencing_correction`, and `/radar_calibration` metadata subgroups. These are mostly empty or sparsely populated and excluded by default for a leaner DataTree.
- `xr.open_dataset()` with `site_coords=True` (single-sweep access) continues to work unchanged.

## Motivation: performance and compliance

Profiling a 6-month KVNX radar DataTree (126 zarr groups, 1868 arrays) on EC2 revealed structural inefficiencies in how xradar builds DataTrees:

| Finding | Impact | This PR |
|---------|--------|---------|
| **F6**: Station coords stored as data_vars, not coordinates | Not recognized as coordinates by downstream tooling | Promoted to root coords via `set_coords()` |
| **F7**: 14 empty/coords-only metadata subgroups per tree | ~70 wasted I/O operations (14 groups × ~5 metadata reads) | `optional_groups=False` by default excludes them |

### CfRadial 2.0 compliance

All three metadata subgroups are **explicitly optional** per the CfRadial 2.0 spec:
- **Section 3.1** (p14): "A number of optional groups are available in the root group"
- **Figure 3.3** (p17): Caption: "Optional metadata groups (highlighted in gray)"
- **Sections 7, 7.5**: Each subgroup described as optional

## Test plan

- [x] All existing IO tests pass (270/270, 8 pre-existing failures unrelated to this PR)
- [x] Station coords are root coordinates (`dtree.ds.coords["latitude"]`)
- [x] Station coords are NOT root data_vars
- [x] Station coords remain on sweeps for backward compatibility
- [x] `optional_groups=True` preserves metadata subgroups
- [x] Roundtrip cfradial2 tests pass with `optional_groups=True`
- [x] Pre-commit hooks pass