### PR TITLE
feat(nexrad): parse AVSET/SAILS/MRLE flags from ICD Messages 2 and 5

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -10,6 +10,7 @@
 * ADD: ``incomplete_sweep`` parameter (``"drop"``/``"pad"``) to ``open_nexradlevel2_datatree`` for handling incomplete sweeps in partial volume data ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * ADD: Notebook example for streaming NEXRAD Level 2 chunks from S3 (``nexrad_read_chunks.ipynb``) ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * ADD: Comprehensive test suite for chunk list-input and incomplete sweep handling ({pull}`332`) by [@aladinor](https://github.com/aladinor)
+* ENH: Expose NEXRAD ICD scan metadata (AVSET/SAILS/MRLE/MPDA/BASE TILT flags, VCP sequencing, per-sweep waveform data) as FM301-compliant user-defined attributes ({issue}`338`, {pull}`339`) by [@aladinor](https://github.com/aladinor)
 * FIX: Set indexes and wrap variables in CopyOnWriteArray for ODIM and GAMIC backends, fixes pickle error for `BufferedReader` ({issue}`189`) by [@Ockenfuss](https://github.com/Ockenfuss), ({pull}`345`) by [@kmuehlbauer](https://github.com/kmuehlbauer)
 * FIX: Allow passing ``inherit`` parameter to ``apply_to_sweeps`` / ``map_over_sweeps`` to control coordinate inheritance from root node ({issue}`343`, {pull}`344`) by [@aladinor](https://github.com/aladinor)
 * FIX: Use ``open-radar-data`` fixture as fallback for ``nexrad_read_chunks.ipynb`` notebook, replacing dependency on ephemeral S3 chunk data ({issue}`351`, {pull}`352`) by [@aladinor](https://github.com/aladinor)

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -783,6 +783,7 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
         "ebc_enabled",
         "super_res_status",
         "rda_build_number",
+        "actual_elevation_cuts",
     }
     assert required_attrs.issubset(dtree.attrs)
     assert dtree.attrs["instrument_name"] == "KATX"
@@ -790,6 +791,8 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
     assert dtree.attrs["dynamic_scan_type"] == "standard"
     assert dtree.attrs["avset_enabled"] is False
     assert dtree.attrs["base_tilt_vcp"] is False
+    # User-specified 5 sweeps out of 16 VCP-defined cuts
+    assert dtree.attrs["actual_elevation_cuts"] == 5
     assert dtree.attrs["mpda_vcp"] is False
 
 
@@ -852,6 +855,7 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
         "ebc_enabled",
         "super_res_status",
         "rda_build_number",
+        "actual_elevation_cuts",
     }
     assert required_attrs.issubset(dtree.attrs)
     assert dtree.attrs["instrument_name"] == "KLIX"

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -757,7 +757,7 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
 
     # Verify a sample variable in one of the sweep groups (adjust as needed based on expected variables)
     sample_sweep = sweep_groups[0]
-    assert len(dtree[sample_sweep].data_vars) == 18
+    assert len(dtree[sample_sweep].data_vars) == 9
     assert (
         "DBZH" in dtree[sample_sweep].data_vars
     ), f"DBZH should be a data variable in {sample_sweep}"
@@ -2386,20 +2386,20 @@ def test_root_attrs_from_real_file(nexradlevel2_file):
     assert isinstance(attrs["operational_mode"], int)
 
 
-def test_sweep_vars_from_real_file(nexradlevel2_file):
-    """Per-sweep vars include waveform and supplemental data."""
+def test_sweep_attrs_from_real_file(nexradlevel2_file):
+    """Per-sweep attrs include waveform and supplemental data from MSG_5_ELEV."""
     dtree = open_nexradlevel2_datatree(nexradlevel2_file, sweep=[0])
-    sweep_ds = dtree["sweep_0"].to_dataset()
+    attrs = dtree["sweep_0"].ds.attrs
 
-    assert sweep_ds["waveform_type"].item() in _WAVEFORM_TYPES.values()
-    assert sweep_ds["channel_config"].item() in _CHANNEL_CONFIGS.values()
-    assert isinstance(sweep_ds["super_resolution"].item(), (int, np.integer))
-    assert isinstance(sweep_ds["sails_cut"].item(), (bool, np.bool_))
-    assert isinstance(sweep_ds["mrle_cut"].item(), (bool, np.bool_))
-    assert isinstance(sweep_ds["mpda_cut"].item(), (bool, np.bool_))
-    assert isinstance(sweep_ds["base_tilt_cut"].item(), (bool, np.bool_))
-    assert isinstance(sweep_ds["sails_sequence_number"].item(), (int, np.integer))
-    assert isinstance(sweep_ds["mrle_sequence_number"].item(), (int, np.integer))
+    assert attrs["waveform_type"] in _WAVEFORM_TYPES.values()
+    assert attrs["channel_config"] in _CHANNEL_CONFIGS.values()
+    assert isinstance(attrs["super_resolution"], int)
+    assert isinstance(attrs["sails_cut"], bool)
+    assert isinstance(attrs["mrle_cut"], bool)
+    assert isinstance(attrs["mpda_cut"], bool)
+    assert isinstance(attrs["base_tilt_cut"], bool)
+    assert isinstance(attrs["sails_sequence_number"], int)
+    assert isinstance(attrs["mrle_sequence_number"], int)
 
 
 def test_get_dynamic_scan_type():

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -116,6 +116,29 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                 ("clutter_map_group_number", 1),
                 ("doppler_velocity_resolution", 2),
                 ("pulse_width", 2),
+                ("vcp_sequencing", 0),
+                ("vcp_supplemental", 0),
+                (
+                    "vcp_sequencing_decoded",
+                    {
+                        "num_elevations": 0,
+                        "max_sails_cuts": 0,
+                        "sequence_active": False,
+                        "truncated_vcp": False,
+                    },
+                ),
+                (
+                    "vcp_supplemental_decoded",
+                    {
+                        "sails_vcp": False,
+                        "num_sails_cuts": 0,
+                        "mrle_vcp": False,
+                        "num_mrle_cuts": 0,
+                        "mpda_vcp": False,
+                        "base_tilt_vcp": False,
+                        "num_base_tilts": 0,
+                    },
+                ),
                 (
                     "elevation_data",
                     [
@@ -137,12 +160,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 0),
                                 ("dop_prf_num_1", 0),
                                 ("dop_prf_pulse_count_1", 0),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 0),
                                 ("dop_prf_num_2", 0),
                                 ("dop_prf_pulse_count_2", 0),
                                 ("edge_angle_3", 0),
                                 ("dop_prf_num_3", 0),
                                 ("dop_prf_pulse_count_3", 0),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -163,12 +198,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 75),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 75),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 75),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -189,12 +236,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 0),
                                 ("dop_prf_num_1", 0),
                                 ("dop_prf_pulse_count_1", 0),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 0),
                                 ("dop_prf_num_2", 0),
                                 ("dop_prf_pulse_count_2", 0),
                                 ("edge_angle_3", 0),
                                 ("dop_prf_num_3", 0),
                                 ("dop_prf_pulse_count_3", 0),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -215,12 +274,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 75),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 75),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 75),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -241,12 +312,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 59),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 59),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 59),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -267,12 +350,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 59),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 59),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 59),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -293,12 +388,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 59),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 59),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 59),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -319,12 +426,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 4),
                                 ("dop_prf_pulse_count_1", 59),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 4),
                                 ("dop_prf_pulse_count_2", 59),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 4),
                                 ("dop_prf_pulse_count_3", 59),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -345,12 +464,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 7),
                                 ("dop_prf_pulse_count_1", 82),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 7),
                                 ("dop_prf_pulse_count_2", 82),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 7),
                                 ("dop_prf_pulse_count_3", 82),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -371,12 +502,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 7),
                                 ("dop_prf_pulse_count_1", 82),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 7),
                                 ("dop_prf_pulse_count_2", 82),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 7),
                                 ("dop_prf_pulse_count_3", 82),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                         OrderedDict(
@@ -397,12 +540,24 @@ def test_open_nexradlevel2_file(nexradlevel2_files):
                                 ("edge_angle_1", 5464),
                                 ("dop_prf_num_1", 7),
                                 ("dop_prf_pulse_count_1", 82),
+                                ("supplemental_data", 0),
                                 ("edge_angle_2", 38232),
                                 ("dop_prf_num_2", 7),
                                 ("dop_prf_pulse_count_2", 82),
                                 ("edge_angle_3", 60984),
                                 ("dop_prf_num_3", 7),
                                 ("dop_prf_pulse_count_3", 82),
+                                (
+                                    "supplemental_data_decoded",
+                                    {
+                                        "sails_cut": False,
+                                        "sails_sequence_number": 0,
+                                        "mrle_cut": False,
+                                        "mrle_sequence_number": 0,
+                                        "mpda_cut": False,
+                                        "base_tilt_cut": False,
+                                    },
+                                ),
                             ]
                         ),
                     ],
@@ -503,6 +658,29 @@ def test_open_nexradlevel2_msg1_file(nexradlevel2_msg1_file):
                 ("clutter_map_group_number", 0),
                 ("doppler_velocity_resolution", 0),
                 ("pulse_width", 0),
+                ("vcp_sequencing", 0),
+                ("vcp_supplemental", 0),
+                (
+                    "vcp_sequencing_decoded",
+                    {
+                        "num_elevations": 0,
+                        "max_sails_cuts": 0,
+                        "sequence_active": False,
+                        "truncated_vcp": False,
+                    },
+                ),
+                (
+                    "vcp_supplemental_decoded",
+                    {
+                        "sails_vcp": False,
+                        "num_sails_cuts": 0,
+                        "mrle_vcp": False,
+                        "num_mrle_cuts": 0,
+                        "mpda_vcp": False,
+                        "base_tilt_vcp": False,
+                        "num_base_tilts": 0,
+                    },
+                ),
                 ("elevation_data", []),
             ]
         )
@@ -859,7 +1037,18 @@ def test_nexradlevel2_msg5_elevation_validation(
 
     # Create mock MSG_5 data with specified parameters
     mock_msg5_data = struct.pack(
-        ">HHHHHBB10s", 0, 0, pattern_number, elevation_cuts, 0, 0, 0, b"\x00" * 10
+        ">HHHHHBB4sHH2s",
+        0,
+        0,
+        pattern_number,
+        elevation_cuts,
+        0,
+        0,
+        0,
+        b"\x00" * 4,
+        0,
+        0,
+        b"\x00" * 2,
     )
 
     # Mock the file reading components
@@ -937,7 +1126,20 @@ def test_nexradlevel2_msg5_struct_error_handling():
             self.read_count += 1
             if self.read_count == 1:
                 # First read - return valid MSG_5 header with 3 elevation cuts
-                return struct.pack(">HHHHHBB10s", 0, 0, 11, 3, 0, 0, 0, b"\x00" * 10)
+                return struct.pack(
+                    ">HHHHHBB4sHH2s",
+                    0,
+                    0,
+                    11,
+                    3,
+                    0,
+                    0,
+                    0,
+                    b"\x00" * 4,
+                    0,
+                    0,
+                    b"\x00" * 2,
+                )
             else:
                 # Subsequent reads - return insufficient data to trigger struct.error
                 return b"\x00" * 10  # Too small for MSG_5_ELEV structure
@@ -1993,3 +2195,149 @@ class TestRealChunkFiles:
 
         assert len(dtree.match("sweep_*")) > 0
         assert "DBZH" in dtree["sweep_0"].data_vars
+
+
+# --- Bit decoder unit tests ---
+
+
+def test_decode_vcp_sequencing():
+    from xradar.io.backends.nexrad_level2 import decode_vcp_sequencing
+
+    # All zeros
+    result = decode_vcp_sequencing(0)
+    assert result == {
+        "num_elevations": 0,
+        "max_sails_cuts": 0,
+        "sequence_active": False,
+        "truncated_vcp": False,
+    }
+    # 5 elevations, 2 max SAILS cuts, sequence active
+    result = decode_vcp_sequencing(0x2045)
+    assert result["num_elevations"] == 5
+    assert result["max_sails_cuts"] == 2
+    assert result["sequence_active"] is True
+    assert result["truncated_vcp"] is False
+    # Truncated VCP
+    result = decode_vcp_sequencing(0x4000)
+    assert result["truncated_vcp"] is True
+
+
+def test_decode_vcp_supplemental():
+    from xradar.io.backends.nexrad_level2 import decode_vcp_supplemental
+
+    # All zeros
+    result = decode_vcp_supplemental(0)
+    assert result["sails_vcp"] is False
+    assert result["num_sails_cuts"] == 0
+    assert result["mrle_vcp"] is False
+    assert result["num_mrle_cuts"] == 0
+    assert result["mpda_vcp"] is False
+    assert result["base_tilt_vcp"] is False
+    assert result["num_base_tilts"] == 0
+    # SAILS VCP with 2 cuts
+    result = decode_vcp_supplemental(0x0005)
+    assert result["sails_vcp"] is True
+    assert result["num_sails_cuts"] == 2
+    assert result["mrle_vcp"] is False
+    # MRLE VCP with 3 cuts
+    result = decode_vcp_supplemental(0x0070)
+    assert result["mrle_vcp"] is True
+    assert result["num_mrle_cuts"] == 3
+    assert result["sails_vcp"] is False
+    # MPDA VCP
+    result = decode_vcp_supplemental(0x0800)
+    assert result["mpda_vcp"] is True
+    # BASE TILT VCP with 1 base tilt
+    result = decode_vcp_supplemental(0x3000)
+    assert result["base_tilt_vcp"] is True
+    assert result["num_base_tilts"] == 1
+
+
+def test_decode_elevation_supplemental():
+    from xradar.io.backends.nexrad_level2 import decode_elevation_supplemental
+
+    # All zeros
+    result = decode_elevation_supplemental(0)
+    assert result["sails_cut"] is False
+    assert result["sails_sequence_number"] == 0
+    assert result["mrle_cut"] is False
+    assert result["mrle_sequence_number"] == 0
+    assert result["mpda_cut"] is False
+    assert result["base_tilt_cut"] is False
+    # SAILS cut, sequence 1
+    result = decode_elevation_supplemental(0x0003)
+    assert result["sails_cut"] is True
+    assert result["sails_sequence_number"] == 1
+    assert result["mrle_cut"] is False
+    # MRLE cut, sequence 2
+    result = decode_elevation_supplemental(0x0050)
+    assert result["mrle_cut"] is True
+    assert result["mrle_sequence_number"] == 2
+    assert result["sails_cut"] is False
+    # MPDA cut
+    result = decode_elevation_supplemental(0x0200)
+    assert result["mpda_cut"] is True
+    # BASE TILT cut
+    result = decode_elevation_supplemental(0x0400)
+    assert result["base_tilt_cut"] is True
+
+
+def test_decode_rda_scan_data_flags():
+    from xradar.io.backends.nexrad_level2 import decode_rda_scan_data_flags
+
+    # All zeros
+    result = decode_rda_scan_data_flags(0)
+    assert result["avset_enabled"] is False
+    assert result["avset_disabled"] is False
+    assert result["ebc_enabled"] is False
+    assert result["rda_log_data_enabled"] is False
+    assert result["time_series_recording"] is False
+    # AVSET enabled
+    result = decode_rda_scan_data_flags(0x0002)
+    assert result["avset_enabled"] is True
+    assert result["avset_disabled"] is False
+    # AVSET disabled
+    result = decode_rda_scan_data_flags(0x0004)
+    assert result["avset_enabled"] is False
+    assert result["avset_disabled"] is True
+    # EBC enabled + RDA log enabled
+    result = decode_rda_scan_data_flags(0x0018)
+    assert result["ebc_enabled"] is True
+    assert result["rda_log_data_enabled"] is True
+
+
+# --- MSG_2 integration tests ---
+
+
+def test_nexradlevel2_msg2_data(nexradlevel2_file):
+    with NEXRADLevel2File(nexradlevel2_file, loaddata=False) as nex:
+        msg_2 = nex.msg_2
+        assert msg_2 is not False
+        assert "rda_status" in msg_2
+        assert "rda_scan_data_flags" in msg_2
+        assert "rda_scan_data_flags_decoded" in msg_2
+        decoded = msg_2["rda_scan_data_flags_decoded"]
+        assert isinstance(decoded["avset_enabled"], bool)
+        assert isinstance(decoded["avset_disabled"], bool)
+        assert isinstance(decoded["ebc_enabled"], bool)
+
+
+def test_nexradlevel2_missing_msg2_returns_false():
+    """Test that msg_2 returns False when MSG_2 metadata is missing."""
+
+    class MockNEXRADFile(NEXRADLevel2File):
+        def __init__(self):
+            self._msg_2_data = None
+            self._meta_header = {"msg_2": []}
+
+        def get_msg_2_data(self):
+            if self.meta_header["msg_2"]:
+                return {}
+            return False
+
+        @property
+        def meta_header(self):
+            return self._meta_header
+
+    mock = MockNEXRADFile()
+    assert mock.msg_2 is False

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -791,8 +791,8 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
     assert dtree.attrs["dynamic_scan_type"] == "standard"
     assert dtree.attrs["avset_enabled"] is False
     assert dtree.attrs["base_tilt_vcp"] is False
-    # User-specified 5 sweeps out of 16 VCP-defined cuts
-    assert dtree.attrs["actual_elevation_cuts"] == 5
+    # actual_elevation_cuts reflects sweeps in the file, not user selection
+    assert dtree.attrs["actual_elevation_cuts"] == dtree.attrs["number_elevation_cuts"]
     assert dtree.attrs["mpda_vcp"] is False
 
 

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -16,8 +16,6 @@ import xarray
 from xarray import DataTree, open_dataset, open_mfdataset
 
 from xradar.io.backends.nexrad_level2 import (
-    _CHANNEL_CONFIGS,
-    _WAVEFORM_TYPES,
     NexradLevel2BackendEntrypoint,
     NEXRADLevel2File,
     open_nexradlevel2_datatree,
@@ -772,7 +770,21 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    assert len(dtree.attrs) == 24
+    required_attrs = {
+        "instrument_name",
+        "scan_name",
+        "dynamic_scan_type",
+        "avset_enabled",
+        "base_tilt_vcp",
+        "mpda_vcp",
+        "vcp_truncated",
+        "doppler_velocity_resolution",
+        "vcp_pulse_width",
+        "ebc_enabled",
+        "super_res_status",
+        "rda_build_number",
+    }
+    assert required_attrs.issubset(dtree.attrs)
     assert dtree.attrs["instrument_name"] == "KATX"
     assert dtree.attrs["scan_name"] == "VCP-11"
     assert dtree.attrs["dynamic_scan_type"] == "standard"
@@ -827,19 +839,23 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    assert len(dtree.attrs) == 24
+    required_attrs = {
+        "instrument_name",
+        "scan_name",
+        "dynamic_scan_type",
+        "avset_enabled",
+        "base_tilt_vcp",
+        "mpda_vcp",
+        "vcp_truncated",
+        "doppler_velocity_resolution",
+        "vcp_pulse_width",
+        "ebc_enabled",
+        "super_res_status",
+        "rda_build_number",
+    }
+    assert required_attrs.issubset(dtree.attrs)
     assert dtree.attrs["instrument_name"] == "KLIX"
     assert dtree.attrs["scan_name"] == "VCP-0"
-    assert "dynamic_scan_type" in dtree.attrs
-    assert "avset_enabled" in dtree.attrs
-    assert "base_tilt_vcp" in dtree.attrs
-    assert "mpda_vcp" in dtree.attrs
-    assert "vcp_truncated" in dtree.attrs
-    assert "doppler_velocity_resolution" in dtree.attrs
-    assert "vcp_pulse_width" in dtree.attrs
-    assert "ebc_enabled" in dtree.attrs
-    assert "super_res_status" in dtree.attrs
-    assert "rda_build_number" in dtree.attrs
 
 
 def test_open_nexradlevel2_datatree_optional_groups(nexradlevel2_file):
@@ -2231,14 +2247,19 @@ def test_decode_vcp_sequencing():
         "truncated_vcp": False,
     }
     # 5 elevations, 2 max SAILS cuts, sequence active
-    result = decode_vcp_sequencing(0x2045)
-    assert result["num_elevations"] == 5
-    assert result["max_sails_cuts"] == 2
-    assert result["sequence_active"] is True
-    assert result["truncated_vcp"] is False
-    # Truncated VCP
-    result = decode_vcp_sequencing(0x4000)
-    assert result["truncated_vcp"] is True
+    assert decode_vcp_sequencing(0x2045) == {
+        "num_elevations": 5,
+        "max_sails_cuts": 2,
+        "sequence_active": True,
+        "truncated_vcp": False,
+    }
+    # Truncated VCP only
+    assert decode_vcp_sequencing(0x4000) == {
+        "num_elevations": 0,
+        "max_sails_cuts": 0,
+        "sequence_active": False,
+        "truncated_vcp": True,
+    }
 
 
 def test_decode_vcp_supplemental():
@@ -2254,22 +2275,30 @@ def test_decode_vcp_supplemental():
     assert result["base_tilt_vcp"] is False
     assert result["num_base_tilts"] == 0
     # SAILS VCP with 2 cuts
-    result = decode_vcp_supplemental(0x0005)
-    assert result["sails_vcp"] is True
-    assert result["num_sails_cuts"] == 2
-    assert result["mrle_vcp"] is False
+    assert decode_vcp_supplemental(0x0005) == {
+        "sails_vcp": True,
+        "num_sails_cuts": 2,
+        "mrle_vcp": False,
+        "num_mrle_cuts": 0,
+        "mpda_vcp": False,
+        "base_tilt_vcp": False,
+        "num_base_tilts": 0,
+    }
     # MRLE VCP with 3 cuts
-    result = decode_vcp_supplemental(0x0070)
-    assert result["mrle_vcp"] is True
-    assert result["num_mrle_cuts"] == 3
-    assert result["sails_vcp"] is False
+    assert decode_vcp_supplemental(0x0070) == {
+        "sails_vcp": False,
+        "num_sails_cuts": 0,
+        "mrle_vcp": True,
+        "num_mrle_cuts": 3,
+        "mpda_vcp": False,
+        "base_tilt_vcp": False,
+        "num_base_tilts": 0,
+    }
     # MPDA VCP
-    result = decode_vcp_supplemental(0x0800)
-    assert result["mpda_vcp"] is True
+    assert decode_vcp_supplemental(0x0800)["mpda_vcp"] is True
     # BASE TILT VCP with 1 base tilt
-    result = decode_vcp_supplemental(0x3000)
-    assert result["base_tilt_vcp"] is True
-    assert result["num_base_tilts"] == 1
+    assert decode_vcp_supplemental(0x3000)["base_tilt_vcp"] is True
+    assert decode_vcp_supplemental(0x3000)["num_base_tilts"] == 1
 
 
 def test_decode_elevation_supplemental():
@@ -2284,21 +2313,27 @@ def test_decode_elevation_supplemental():
     assert result["mpda_cut"] is False
     assert result["base_tilt_cut"] is False
     # SAILS cut, sequence 1
-    result = decode_elevation_supplemental(0x0003)
-    assert result["sails_cut"] is True
-    assert result["sails_sequence_number"] == 1
-    assert result["mrle_cut"] is False
+    assert decode_elevation_supplemental(0x0003) == {
+        "sails_cut": True,
+        "sails_sequence_number": 1,
+        "mrle_cut": False,
+        "mrle_sequence_number": 0,
+        "mpda_cut": False,
+        "base_tilt_cut": False,
+    }
     # MRLE cut, sequence 2
-    result = decode_elevation_supplemental(0x0050)
-    assert result["mrle_cut"] is True
-    assert result["mrle_sequence_number"] == 2
-    assert result["sails_cut"] is False
+    assert decode_elevation_supplemental(0x0050) == {
+        "sails_cut": False,
+        "sails_sequence_number": 0,
+        "mrle_cut": True,
+        "mrle_sequence_number": 2,
+        "mpda_cut": False,
+        "base_tilt_cut": False,
+    }
     # MPDA cut
-    result = decode_elevation_supplemental(0x0200)
-    assert result["mpda_cut"] is True
+    assert decode_elevation_supplemental(0x0200)["mpda_cut"] is True
     # BASE TILT cut
-    result = decode_elevation_supplemental(0x0400)
-    assert result["base_tilt_cut"] is True
+    assert decode_elevation_supplemental(0x0400)["base_tilt_cut"] is True
 
 
 def test_decode_rda_scan_data_flags():
@@ -2391,15 +2426,17 @@ def test_sweep_attrs_from_real_file(nexradlevel2_file):
     dtree = open_nexradlevel2_datatree(nexradlevel2_file, sweep=[0])
     attrs = dtree["sweep_0"].ds.attrs
 
-    assert attrs["waveform_type"] in _WAVEFORM_TYPES.values()
-    assert attrs["channel_config"] in _CHANNEL_CONFIGS.values()
+    # Known values for KATX VCP-11 sweep_0
+    assert attrs["waveform_type"] == "contiguous_surveillance"
+    assert attrs["channel_config"] == "constant_phase"
     assert isinstance(attrs["super_resolution"], int)
-    assert isinstance(attrs["sails_cut"], bool)
-    assert isinstance(attrs["mrle_cut"], bool)
-    assert isinstance(attrs["mpda_cut"], bool)
-    assert isinstance(attrs["base_tilt_cut"], bool)
-    assert isinstance(attrs["sails_sequence_number"], int)
-    assert isinstance(attrs["mrle_sequence_number"], int)
+    # Standard VCP-11: no dynamic scan cuts on sweep_0
+    assert attrs["sails_cut"] is False
+    assert attrs["mrle_cut"] is False
+    assert attrs["mpda_cut"] is False
+    assert attrs["base_tilt_cut"] is False
+    assert attrs["sails_sequence_number"] == 0
+    assert attrs["mrle_sequence_number"] == 0
 
 
 def test_get_dynamic_scan_type():

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -755,7 +755,7 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
 
     # Verify a sample variable in one of the sweep groups (adjust as needed based on expected variables)
     sample_sweep = sweep_groups[0]
-    assert len(dtree[sample_sweep].data_vars) == 9
+    assert len(dtree[sample_sweep].data_vars) == 18
     assert (
         "DBZH" in dtree[sample_sweep].data_vars
     ), f"DBZH should be a data variable in {sample_sweep}"
@@ -770,9 +770,13 @@ def test_open_nexradlevel2_datatree(nexradlevel2_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    assert len(dtree.attrs) == 10
+    assert len(dtree.attrs) == 24
     assert dtree.attrs["instrument_name"] == "KATX"
     assert dtree.attrs["scan_name"] == "VCP-11"
+    assert dtree.attrs["dynamic_scan_type"] == "standard"
+    assert dtree.attrs["avset_enabled"] is False
+    assert dtree.attrs["base_tilt_vcp"] is False
+    assert dtree.attrs["mpda_vcp"] is False
 
 
 def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
@@ -821,9 +825,19 @@ def test_open_nexradlevel2_msg1_datatree(nexradlevel2_msg1_file):
     assert "altitude" in dtree.ds.coords
     assert "latitude" not in dtree.ds.data_vars
 
-    assert len(dtree.attrs) == 10
+    assert len(dtree.attrs) == 24
     assert dtree.attrs["instrument_name"] == "KLIX"
     assert dtree.attrs["scan_name"] == "VCP-0"
+    assert "dynamic_scan_type" in dtree.attrs
+    assert "avset_enabled" in dtree.attrs
+    assert "base_tilt_vcp" in dtree.attrs
+    assert "mpda_vcp" in dtree.attrs
+    assert "vcp_truncated" in dtree.attrs
+    assert "doppler_velocity_resolution" in dtree.attrs
+    assert "vcp_pulse_width" in dtree.attrs
+    assert "ebc_enabled" in dtree.attrs
+    assert "super_res_status" in dtree.attrs
+    assert "rda_build_number" in dtree.attrs
 
 
 def test_open_nexradlevel2_datatree_optional_groups(nexradlevel2_file):

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -965,6 +965,7 @@ def test_nexradlevel2_missing_msg2_metadata():
 
     class MockNEXRADFile(NEXRADLevel2File):
         def __init__(self):
+            self._fp = None
             self._meta_header = defaultdict(list)
             # Simulate missing msg_2 by only having other message types
             self._meta_header["msg_15"] = [{"record_number": 0}]
@@ -1095,6 +1096,7 @@ def test_nexradlevel2_missing_msg5():
 
     class MockNEXRADFile(NEXRADLevel2File):
         def __init__(self):
+            self._fp = None
             self._meta_header = defaultdict(list)  # Empty - no msg_5
             self._msg_5_data = None
             self._rawdata = False
@@ -1146,6 +1148,7 @@ def test_nexradlevel2_msg5_struct_error_handling():
 
     class MockNEXRADFile(NEXRADLevel2File):
         def __init__(self):
+            self._fp = None
             self._meta_header = defaultdict(list)
             self._meta_header["msg_5"] = [{"record_number": 0}]
             self._msg_5_data = None
@@ -2327,13 +2330,9 @@ def test_nexradlevel2_missing_msg2_returns_false():
 
     class MockNEXRADFile(NEXRADLevel2File):
         def __init__(self):
+            self._fp = None
             self._msg_2_data = None
             self._meta_header = {"msg_2": []}
-
-        def get_msg_2_data(self):
-            if self.meta_header["msg_2"]:
-                return {}
-            return False
 
         @property
         def meta_header(self):

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -16,6 +16,8 @@ import xarray
 from xarray import DataTree, open_dataset, open_mfdataset
 
 from xradar.io.backends.nexrad_level2 import (
+    _CHANNEL_CONFIGS,
+    _WAVEFORM_TYPES,
     NexradLevel2BackendEntrypoint,
     NEXRADLevel2File,
     open_nexradlevel2_datatree,
@@ -2354,3 +2356,61 @@ def test_nexradlevel2_missing_msg2_returns_false():
 
     mock = MockNEXRADFile()
     assert mock.msg_2 is False
+
+
+def test_root_attrs_from_real_file(nexradlevel2_file):
+    """Root attrs include all expected ICD scan metadata fields."""
+    dtree = open_nexradlevel2_datatree(nexradlevel2_file, sweep=[0])
+    attrs = dtree.attrs
+
+    # MSG_5 attrs
+    assert attrs["scan_name"].startswith("VCP-")
+    assert (
+        attrs["dynamic_scan_type"] in ("standard", "SAILS", "MRLE")
+        or "x" in attrs["dynamic_scan_type"]
+    )
+    assert isinstance(attrs["mpda_vcp"], bool)
+    assert isinstance(attrs["base_tilt_vcp"], bool)
+    assert isinstance(attrs["num_base_tilts"], int)
+    assert isinstance(attrs["vcp_truncated"], bool)
+    assert isinstance(attrs["vcp_sequence_active"], bool)
+    assert attrs["number_elevation_cuts"] > 0
+    assert attrs["doppler_velocity_resolution"] in (0.5, 1.0)
+    assert attrs["vcp_pulse_width"] in ("short", "long")
+
+    # MSG_2 attrs
+    assert isinstance(attrs["avset_enabled"], bool)
+    assert isinstance(attrs["ebc_enabled"], bool)
+    assert isinstance(attrs["super_res_status"], int)
+    assert isinstance(attrs["rda_build_number"], int)
+    assert isinstance(attrs["operational_mode"], int)
+
+
+def test_sweep_vars_from_real_file(nexradlevel2_file):
+    """Per-sweep vars include waveform and supplemental data."""
+    dtree = open_nexradlevel2_datatree(nexradlevel2_file, sweep=[0])
+    sweep_ds = dtree["sweep_0"].to_dataset()
+
+    assert sweep_ds["waveform_type"].item() in _WAVEFORM_TYPES.values()
+    assert sweep_ds["channel_config"].item() in _CHANNEL_CONFIGS.values()
+    assert isinstance(sweep_ds["super_resolution"].item(), (int, np.integer))
+    assert isinstance(sweep_ds["sails_cut"].item(), (bool, np.bool_))
+    assert isinstance(sweep_ds["mrle_cut"].item(), (bool, np.bool_))
+    assert isinstance(sweep_ds["mpda_cut"].item(), (bool, np.bool_))
+    assert isinstance(sweep_ds["base_tilt_cut"].item(), (bool, np.bool_))
+    assert isinstance(sweep_ds["sails_sequence_number"].item(), (int, np.integer))
+    assert isinstance(sweep_ds["mrle_sequence_number"].item(), (int, np.integer))
+
+
+def test_get_dynamic_scan_type():
+    """Test _get_dynamic_scan_type helper for all cases."""
+    from xradar.io.backends.nexrad_level2 import _get_dynamic_scan_type
+
+    assert _get_dynamic_scan_type({}) == "standard"
+    assert (
+        _get_dynamic_scan_type({"sails_vcp": True, "num_sails_cuts": 3}) == "SAILS x 3"
+    )
+    assert _get_dynamic_scan_type({"mrle_vcp": True, "num_mrle_cuts": 4}) == "MRLE x 4"
+    assert _get_dynamic_scan_type({"sails_vcp": True, "num_sails_cuts": 0}) == "SAILS"
+    assert _get_dynamic_scan_type({"mrle_vcp": True, "num_mrle_cuts": 0}) == "MRLE"
+    assert _get_dynamic_scan_type({"sails_vcp": False, "mrle_vcp": False}) == "standard"

--- a/tests/transform/test_cfradial.py
+++ b/tests/transform/test_cfradial.py
@@ -40,7 +40,10 @@ def test_to_cfradial2(cfradial1_file):
         # Verify key attributes and data structures in the resulting datatree
         assert isinstance(dtree_cf2, xr.DataTree), "Output is not a valid DataTree"
         assert "radar_parameters" in dtree_cf2, "Missing radar_parameters in DataTree"
-        assert dtree_cf2.attrs == ds_cf1.attrs, "Attributes mismatch between formats"
+        # Round-tripped attrs should be a subset of the original — backend-specific
+        # attrs (e.g. NEXRAD ICD metadata) are not preserved by the generic reader.
+        for key, val in dtree_cf2.attrs.items():
+            assert ds_cf1.attrs[key] == val, f"Attr {key!r} mismatch after round-trip"
 
 
 def test_to_cfradial1_with_different_range_shapes(nexradlevel2_bzfile):
@@ -63,7 +66,10 @@ def test_to_cfradial1_with_different_range_shapes(nexradlevel2_bzfile):
         assert isinstance(dtree_cf2, xr.DataTree), "Output is not a valid DataTree"
         # todo: this needs to be fixed in nexrad level2reader
         # assert "radar_parameters" in dtree_cf2, "Missing radar_parameters in DataTree"
-        assert dtree_cf2.attrs == ds_cf1.attrs, "Attributes mismatch between formats"
+        # Round-tripped attrs should be a subset of the original — backend-specific
+        # attrs (e.g. NEXRAD ICD metadata) are not preserved by the generic reader.
+        for key, val in dtree_cf2.attrs.items():
+            assert ds_cf1.attrs[key] == val, f"Attr {key!r} mismatch after round-trip"
 
 
 def test_to_cfradial1_error_with_different_range_bin_sizes(gamic_file):

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -2181,8 +2181,8 @@ def open_nexradlevel2_datatree(
     # Inject per-sweep attrs from MSG_5_ELEV (ICD Table XI)
     _assign_sweep_attrs(result, elev_data)
 
-    # Add actual sweep count to root attrs for AVSET termination detection
-    result.ds.attrs["actual_elevation_cuts"] = len(sweep_dict)
+    # Actual sweeps recorded in the file (from MSG_31 headers, not user selection)
+    result.ds.attrs["actual_elevation_cuts"] = act_sweeps
 
     return result
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1138,6 +1138,32 @@ MSG_5_ELEV = OrderedDict(
 LEN_MSG_5_ELEV = struct.calcsize(_get_fmt_string(MSG_5_ELEV, byte_order=">"))
 
 
+_WAVEFORM_TYPES = {
+    0: "not_applicable",
+    1: "contiguous_surveillance",
+    2: "contiguous_doppler",
+    3: "batch",
+    4: "staggered_pulse_pair",
+}
+
+_CHANNEL_CONFIGS = {
+    0: "constant_phase",
+    1: "random_phase",
+    2: "sz2_phase_coding",
+}
+
+
+def _get_dynamic_scan_type(supplemental):
+    """Derive dynamic scan type string from VCP supplemental decoded dict."""
+    if supplemental.get("sails_vcp"):
+        n = supplemental.get("num_sails_cuts", 0)
+        return f"SAILS x {n}" if n else "SAILS"
+    elif supplemental.get("mrle_vcp"):
+        n = supplemental.get("num_mrle_cuts", 0)
+        return f"MRLE x {n}" if n else "MRLE"
+    return "standard"
+
+
 def decode_vcp_sequencing(value):
     """Decode VCP Sequencing Values (MSG_5 HW 9, ICD 2620002AA Note 15)."""
     return {
@@ -1764,6 +1790,28 @@ class NexradLevel2Store(AbstractDataStore):
             "sweep_fixed_angle": Variable((), fixed_angle),
         }
 
+        # Per-sweep waveform and supplemental data from MSG_5_ELEV
+        if elev_data:
+            elev_info = elev_data[self._group]
+            wf = elev_info.get("waveform_type", 0)
+            coords["waveform_type"] = Variable((), _WAVEFORM_TYPES.get(wf, str(wf)))
+            ch = elev_info.get("channel_config", 0)
+            coords["channel_config"] = Variable((), _CHANNEL_CONFIGS.get(ch, str(ch)))
+            sr = elev_info.get("super_resolution", 0)
+            coords["super_resolution"] = Variable((), sr)
+            sup = elev_info.get("supplemental_data_decoded", {})
+            if sup:
+                coords["sails_cut"] = Variable((), sup.get("sails_cut", False))
+                coords["sails_sequence_number"] = Variable(
+                    (), sup.get("sails_sequence_number", 0)
+                )
+                coords["mrle_cut"] = Variable((), sup.get("mrle_cut", False))
+                coords["mrle_sequence_number"] = Variable(
+                    (), sup.get("mrle_sequence_number", 0)
+                )
+                coords["mpda_cut"] = Variable((), sup.get("mpda_cut", False))
+                coords["base_tilt_cut"] = Variable((), sup.get("base_tilt_cut", False))
+
         return coords
 
     def get_variables(self):
@@ -1789,9 +1837,49 @@ class NexradLevel2Store(AbstractDataStore):
             _attributes.append(("instrument_name", "UNKNOWN"))
 
         if self.root.msg_5:
+            msg_5 = self.root.msg_5
+            _attributes.append(("scan_name", f"VCP-{msg_5['pattern_number']}"))
+            # dynamic scan type from VCP supplemental (ICD Note 16)
+            supplemental = msg_5.get("vcp_supplemental_decoded", {})
             _attributes.append(
-                ("scan_name", f"VCP-{self.root.msg_5['pattern_number']}")
+                ("dynamic_scan_type", _get_dynamic_scan_type(supplemental))
             )
+            _attributes.append(("mpda_vcp", supplemental.get("mpda_vcp", False)))
+            _attributes.append(
+                ("base_tilt_vcp", supplemental.get("base_tilt_vcp", False))
+            )
+            _attributes.append(
+                ("num_base_tilts", supplemental.get("num_base_tilts", 0))
+            )
+            # VCP sequencing (ICD Note 15)
+            sequencing = msg_5.get("vcp_sequencing_decoded", {})
+            _attributes.append(
+                ("vcp_truncated", sequencing.get("truncated_vcp", False))
+            )
+            _attributes.append(
+                ("vcp_sequence_active", sequencing.get("sequence_active", False))
+            )
+            # VCP-level waveform info
+            _attributes.append(
+                ("number_elevation_cuts", msg_5.get("number_elevation_cuts", 0))
+            )
+            vel_res = msg_5.get("doppler_velocity_resolution", 0)
+            _attributes.append(
+                ("doppler_velocity_resolution", 0.5 if vel_res == 2 else 1.0)
+            )
+            pw = msg_5.get("pulse_width", 0)
+            _attributes.append(
+                ("vcp_pulse_width", "short" if pw == 2 else "long" if pw == 4 else pw)
+            )
+
+        msg_2 = self.root.msg_2
+        if msg_2:
+            flags = msg_2.get("rda_scan_data_flags_decoded", {})
+            _attributes.append(("avset_enabled", flags.get("avset_enabled", False)))
+            _attributes.append(("ebc_enabled", flags.get("ebc_enabled", False)))
+            _attributes.append(("super_res_status", msg_2.get("super_res_status", 0)))
+            _attributes.append(("rda_build_number", msg_2.get("rda_build_number", 0)))
+            _attributes.append(("operational_mode", msg_2.get("operational_mode", 0)))
 
         return FrozenDict(_attributes)
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1153,6 +1153,32 @@ _CHANNEL_CONFIGS = {
 }
 
 
+def _assign_sweep_attrs(dtree, elev_data):
+    """Inject per-sweep attrs from MSG_5_ELEV data onto sweep nodes."""
+    if not elev_data:
+        return
+    for i, elev in enumerate(elev_data):
+        sweep_key = f"sweep_{i}"
+        if sweep_key not in dtree.children:
+            continue
+        wf = elev.get("waveform_type", 0)
+        ch = elev.get("channel_config", 0)
+        sup = elev.get("supplemental_data_decoded", {})
+        dtree[sweep_key].ds.attrs.update(
+            {
+                "waveform_type": _WAVEFORM_TYPES.get(wf, str(wf)),
+                "channel_config": _CHANNEL_CONFIGS.get(ch, str(ch)),
+                "super_resolution": elev.get("super_resolution", 0),
+                "sails_cut": sup.get("sails_cut", False),
+                "sails_sequence_number": sup.get("sails_sequence_number", 0),
+                "mrle_cut": sup.get("mrle_cut", False),
+                "mrle_sequence_number": sup.get("mrle_sequence_number", 0),
+                "mpda_cut": sup.get("mpda_cut", False),
+                "base_tilt_cut": sup.get("base_tilt_cut", False),
+            }
+        )
+
+
 def _get_dynamic_scan_type(supplemental):
     """Derive dynamic scan type string from VCP supplemental decoded dict."""
     if supplemental.get("sails_vcp"):
@@ -1790,28 +1816,6 @@ class NexradLevel2Store(AbstractDataStore):
             "sweep_fixed_angle": Variable((), fixed_angle),
         }
 
-        # Per-sweep metadata from MSG_5_ELEV (ICD Table XI)
-        if elev_data:
-            elev_info = elev_data[self._group]
-            wf = elev_info.get("waveform_type", 0)
-            ch = elev_info.get("channel_config", 0)
-            coords["waveform_type"] = Variable((), _WAVEFORM_TYPES.get(wf, str(wf)))
-            coords["channel_config"] = Variable((), _CHANNEL_CONFIGS.get(ch, str(ch)))
-            coords["super_resolution"] = Variable(
-                (), elev_info.get("super_resolution", 0)
-            )
-            # Per-elevation supplemental data (ICD Note 17, E15)
-            sup = elev_info.get("supplemental_data_decoded", {})
-            for key in (
-                "sails_cut",
-                "mrle_cut",
-                "mpda_cut",
-                "base_tilt_cut",
-            ):
-                coords[key] = Variable((), sup.get(key, False))
-            for key in ("sails_sequence_number", "mrle_sequence_number"):
-                coords[key] = Variable((), sup.get(key, 0))
-
         return coords
 
     def get_variables(self):
@@ -2078,6 +2082,7 @@ def open_nexradlevel2_datatree(
             )
 
     incomplete = set()
+    elev_data = []
 
     if isinstance(sweep, str):
         sweep = NodePath(sweep).name
@@ -2098,6 +2103,7 @@ def open_nexradlevel2_datatree(
             # Expected number of elevation cuts from the VCP definition
             if nex.msg_5:
                 exp_sweeps = nex.msg_5["number_elevation_cuts"]
+                elev_data = nex.msg_5.get("elevation_data", [])
             else:
                 exp_sweeps = 0
             # Actual number of sweeps recorded in the file
@@ -2141,6 +2147,14 @@ def open_nexradlevel2_datatree(
     if incomplete_sweep == "pad" and not incomplete:
         with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
             incomplete = nex.incomplete_sweeps
+            if not elev_data and nex.msg_5:
+                elev_data = nex.msg_5.get("elevation_data", [])
+
+    # Read elevation metadata for per-sweep attrs if not yet available
+    if not elev_data:
+        with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
+            if nex.msg_5:
+                elev_data = nex.msg_5.get("elevation_data", [])
 
     sweep_dict = open_sweeps_as_dict(
         filename_or_obj=filename_or_obj,
@@ -2174,7 +2188,12 @@ def open_nexradlevel2_datatree(
         )
     # Build from ls_ds (station vars already stripped by _assign_root).
     dtree |= {key: ds.drop_attrs(deep=False) for key, ds in zip(sweep_dict, ls_ds[1:])}
-    return DataTree.from_dict(dtree)
+    result = DataTree.from_dict(dtree)
+
+    # Inject per-sweep attrs from MSG_5_ELEV (ICD Table XI)
+    _assign_sweep_attrs(result, elev_data)
+
+    return result
 
 
 def open_sweeps_as_dict(

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -2181,6 +2181,9 @@ def open_nexradlevel2_datatree(
     # Inject per-sweep attrs from MSG_5_ELEV (ICD Table XI)
     _assign_sweep_attrs(result, elev_data)
 
+    # Add actual sweep count to root attrs for AVSET termination detection
+    result.ds.attrs["actual_elevation_cuts"] = len(sweep_dict)
+
     return result
 
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -538,6 +538,7 @@ class NEXRADLevel2File(NEXRADRecordFile):
         self._msg_5_data = None
         # message 2
         # RDA Status Data
+        self._msg_2_data = None
 
         # message 31 headers
         # Digital Radar Data Generic Format
@@ -592,6 +593,13 @@ class NEXRADLevel2File(NEXRADRecordFile):
         if self._msg_5_data is None:
             self._msg_5_data = self.get_msg_5_data()
         return self._msg_5_data
+
+    @property
+    def msg_2(self):
+        """Retrieve MSG2 (RDA Status) data."""
+        if self._msg_2_data is None:
+            self._msg_2_data = self.get_msg_2_data()
+        return self._msg_2_data
 
     @property
     def data(self):
@@ -685,6 +693,12 @@ class NEXRADLevel2File(NEXRADRecordFile):
             self._rawdata,
             byte_order=">",
         )
+        msg_5["vcp_sequencing_decoded"] = decode_vcp_sequencing(
+            msg_5.get("vcp_sequencing", 0)
+        )
+        msg_5["vcp_supplemental_decoded"] = decode_vcp_supplemental(
+            msg_5.get("vcp_supplemental", 0)
+        )
         msg_5["elevation_data"] = []
 
         # Validate number_elevation_cuts is reasonable
@@ -704,11 +718,33 @@ class NEXRADLevel2File(NEXRADRecordFile):
                     self._rawdata,
                     byte_order=">",
                 )
+                msg_5_elev["supplemental_data_decoded"] = decode_elevation_supplemental(
+                    msg_5_elev.get("supplemental_data", 0)
+                )
                 msg_5["elevation_data"].append(msg_5_elev)
         except (struct.error, EOFError):
             pass
 
         return msg_5
+
+    def get_msg_2_data(self):
+        """Get MSG2 (RDA Status) data."""
+        if self.meta_header["msg_2"]:
+            recnum = self.meta_header["msg_2"][0]["record_number"]
+        else:
+            return False
+        self.init_record(recnum)
+        self.rh.pos += LEN_MSG_HEADER + 12
+        msg_2 = _unpack_dictionary(
+            self._rh.read(LEN_MSG_2, width=1),
+            MSG_2,
+            self._rawdata,
+            byte_order=">",
+        )
+        msg_2["rda_scan_data_flags_decoded"] = decode_rda_scan_data_flags(
+            msg_2.get("rda_scan_data_flags", 0)
+        )
+        return msg_2
 
     def get_message_header(self):
         """Read and unpack message header."""
@@ -1062,7 +1098,10 @@ MSG_5 = OrderedDict(
         ("clutter_map_group_number", UINT2),
         ("doppler_velocity_resolution", CODE1),  # 2: 0.5 degrees, 4: 1.0 degrees
         ("pulse_width", CODE1),  # 2: short, 4: long
-        ("spare", {"fmt": "10s"}),  # halfwords 7-11 (10 bytes, 5 halfwords)
+        ("spare_7_8", {"fmt": "4s"}),  # HW 7-8: Reserved
+        ("vcp_sequencing", CODE2),  # HW 9: VCP sequencing values (ICD Note 15)
+        ("vcp_supplemental", CODE2),  # HW 10: SAILS/MRLE/MPDA flags (ICD Note 16)
+        ("spare_11", {"fmt": "2s"}),  # HW 11: Reserved
     ]
 )
 LEN_MSG_5 = struct.calcsize(_get_fmt_string(MSG_5, byte_order=">"))
@@ -1085,7 +1124,7 @@ MSG_5_ELEV = OrderedDict(
         ("edge_angle_1", CODE2),
         ("dop_prf_num_1", UINT2),
         ("dop_prf_pulse_count_1", UINT2),
-        ("spare_1", {"fmt": "2s"}),
+        ("supplemental_data", CODE2),  # E15: SAILS/MRLE/MPDA per-cut flags
         ("edge_angle_2", CODE2),
         ("dop_prf_num_2", UINT2),
         ("dop_prf_pulse_count_2", UINT2),
@@ -1097,6 +1136,80 @@ MSG_5_ELEV = OrderedDict(
     ]
 )
 LEN_MSG_5_ELEV = struct.calcsize(_get_fmt_string(MSG_5_ELEV, byte_order=">"))
+
+
+def decode_vcp_sequencing(value):
+    """Decode VCP Sequencing Values (MSG_5 HW 9, ICD 2620002AA Note 15)."""
+    return {
+        "num_elevations": value & 0x1F,  # Bits 0-4
+        "max_sails_cuts": (value >> 5) & 0x03,  # Bits 5-6
+        "sequence_active": bool(value & 0x2000),  # Bit 13
+        "truncated_vcp": bool(value & 0x4000),  # Bit 14
+    }
+
+
+def decode_vcp_supplemental(value):
+    """Decode VCP Supplemental Data (MSG_5 HW 10, ICD 2620002AA Note 16)."""
+    return {
+        "sails_vcp": bool(value & 0x0001),  # Bit 0
+        "num_sails_cuts": (value >> 1) & 0x07,  # Bits 1-3
+        "mrle_vcp": bool(value & 0x0010),  # Bit 4
+        "num_mrle_cuts": (value >> 5) & 0x07,  # Bits 5-7
+        # Bits 8-10: Spares per ICD
+        "mpda_vcp": bool(value & 0x0800),  # Bit 11
+        "base_tilt_vcp": bool(value & 0x1000),  # Bit 12
+        "num_base_tilts": (value >> 13) & 0x07,  # Bits 13-15
+    }
+
+
+def decode_elevation_supplemental(value):
+    """Decode per-elevation supplemental data (MSG_5_ELEV E15, ICD Note 17)."""
+    return {
+        "sails_cut": bool(value & 0x0001),  # Bit 0
+        "sails_sequence_number": (value >> 1) & 0x07,  # Bits 1-3
+        "mrle_cut": bool(value & 0x0010),  # Bit 4
+        "mrle_sequence_number": (value >> 5) & 0x07,  # Bits 5-7
+        # Bit 8: Spare
+        "mpda_cut": bool(value & 0x0200),  # Bit 9
+        "base_tilt_cut": bool(value & 0x0400),  # Bit 10
+    }
+
+
+def decode_rda_scan_data_flags(value):
+    """Decode RDA Scan and Data Flags (MSG_2 HW 14, ICD 2620002AA Note 10).
+
+    Bits 1 and 2 are mutually exclusive and represent AVSET status.
+    """
+    return {
+        "avset_enabled": bool(value & 0x0002),  # Bit 1
+        "avset_disabled": bool(value & 0x0004),  # Bit 2
+        "ebc_enabled": bool(value & 0x0008),  # Bit 3
+        "rda_log_data_enabled": bool(value & 0x0010),  # Bit 4
+        "time_series_recording": bool(value & 0x0020),  # Bit 5
+    }
+
+
+# Table IV RDA Status Data (Message Type 2)
+# pages 3-12 to 3-16
+MSG_2 = OrderedDict(
+    [
+        ("rda_status", CODE2),  # HW 1
+        ("operability_status", CODE2),  # HW 2
+        ("control_status", CODE2),  # HW 3
+        ("aux_power_gen_state", CODE2),  # HW 4
+        ("avg_xmtr_power", UINT2),  # HW 5
+        ("horiz_ref_calib_corr", SINT2),  # HW 6
+        ("data_xmission_enabled", CODE2),  # HW 7
+        ("vcp_number", SINT2),  # HW 8
+        ("rda_control_auth", CODE2),  # HW 9
+        ("rda_build_number", UINT2),  # HW 10
+        ("operational_mode", CODE2),  # HW 11
+        ("super_res_status", CODE2),  # HW 12
+        ("cmd_status", CODE2),  # HW 13
+        ("rda_scan_data_flags", CODE2),  # HW 14: AVSET/EBC bits
+    ]
+)
+LEN_MSG_2 = struct.calcsize(_get_fmt_string(MSG_2, byte_order=">"))
 
 MSG_18 = OrderedDict(
     [

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1790,27 +1790,27 @@ class NexradLevel2Store(AbstractDataStore):
             "sweep_fixed_angle": Variable((), fixed_angle),
         }
 
-        # Per-sweep waveform and supplemental data from MSG_5_ELEV
+        # Per-sweep metadata from MSG_5_ELEV (ICD Table XI)
         if elev_data:
             elev_info = elev_data[self._group]
             wf = elev_info.get("waveform_type", 0)
-            coords["waveform_type"] = Variable((), _WAVEFORM_TYPES.get(wf, str(wf)))
             ch = elev_info.get("channel_config", 0)
+            coords["waveform_type"] = Variable((), _WAVEFORM_TYPES.get(wf, str(wf)))
             coords["channel_config"] = Variable((), _CHANNEL_CONFIGS.get(ch, str(ch)))
-            sr = elev_info.get("super_resolution", 0)
-            coords["super_resolution"] = Variable((), sr)
+            coords["super_resolution"] = Variable(
+                (), elev_info.get("super_resolution", 0)
+            )
+            # Per-elevation supplemental data (ICD Note 17, E15)
             sup = elev_info.get("supplemental_data_decoded", {})
-            if sup:
-                coords["sails_cut"] = Variable((), sup.get("sails_cut", False))
-                coords["sails_sequence_number"] = Variable(
-                    (), sup.get("sails_sequence_number", 0)
-                )
-                coords["mrle_cut"] = Variable((), sup.get("mrle_cut", False))
-                coords["mrle_sequence_number"] = Variable(
-                    (), sup.get("mrle_sequence_number", 0)
-                )
-                coords["mpda_cut"] = Variable((), sup.get("mpda_cut", False))
-                coords["base_tilt_cut"] = Variable((), sup.get("base_tilt_cut", False))
+            for key in (
+                "sails_cut",
+                "mrle_cut",
+                "mpda_cut",
+                "base_tilt_cut",
+            ):
+                coords[key] = Variable((), sup.get(key, False))
+            for key in ("sails_sequence_number", "mrle_sequence_number"):
+                coords[key] = Variable((), sup.get(key, 0))
 
         return coords
 
@@ -1827,61 +1827,51 @@ class NexradLevel2Store(AbstractDataStore):
         )
 
     def get_attrs(self):
-        _attributes = []
+        attrs = {}
 
-        if self.root.volume_header is not None:
-            _attributes.append(
-                ("instrument_name", self.root.volume_header["icao"].decode())
-            )
-        else:
-            _attributes.append(("instrument_name", "UNKNOWN"))
+        vh = self.root.volume_header
+        attrs["instrument_name"] = vh["icao"].decode() if vh else "UNKNOWN"
 
         if self.root.msg_5:
-            msg_5 = self.root.msg_5
-            _attributes.append(("scan_name", f"VCP-{msg_5['pattern_number']}"))
-            # dynamic scan type from VCP supplemental (ICD Note 16)
-            supplemental = msg_5.get("vcp_supplemental_decoded", {})
-            _attributes.append(
-                ("dynamic_scan_type", _get_dynamic_scan_type(supplemental))
-            )
-            _attributes.append(("mpda_vcp", supplemental.get("mpda_vcp", False)))
-            _attributes.append(
-                ("base_tilt_vcp", supplemental.get("base_tilt_vcp", False))
-            )
-            _attributes.append(
-                ("num_base_tilts", supplemental.get("num_base_tilts", 0))
-            )
-            # VCP sequencing (ICD Note 15)
-            sequencing = msg_5.get("vcp_sequencing_decoded", {})
-            _attributes.append(
-                ("vcp_truncated", sequencing.get("truncated_vcp", False))
-            )
-            _attributes.append(
-                ("vcp_sequence_active", sequencing.get("sequence_active", False))
-            )
-            # VCP-level waveform info
-            _attributes.append(
-                ("number_elevation_cuts", msg_5.get("number_elevation_cuts", 0))
-            )
-            vel_res = msg_5.get("doppler_velocity_resolution", 0)
-            _attributes.append(
-                ("doppler_velocity_resolution", 0.5 if vel_res == 2 else 1.0)
-            )
-            pw = msg_5.get("pulse_width", 0)
-            _attributes.append(
-                ("vcp_pulse_width", "short" if pw == 2 else "long" if pw == 4 else pw)
-            )
+            attrs.update(self._attrs_from_msg_5(self.root.msg_5))
 
         msg_2 = self.root.msg_2
         if msg_2:
-            flags = msg_2.get("rda_scan_data_flags_decoded", {})
-            _attributes.append(("avset_enabled", flags.get("avset_enabled", False)))
-            _attributes.append(("ebc_enabled", flags.get("ebc_enabled", False)))
-            _attributes.append(("super_res_status", msg_2.get("super_res_status", 0)))
-            _attributes.append(("rda_build_number", msg_2.get("rda_build_number", 0)))
-            _attributes.append(("operational_mode", msg_2.get("operational_mode", 0)))
+            attrs.update(self._attrs_from_msg_2(msg_2))
 
-        return FrozenDict(_attributes)
+        return FrozenDict(attrs)
+
+    @staticmethod
+    def _attrs_from_msg_5(msg_5):
+        """Extract root attributes from MSG_5 (VCP definition)."""
+        supplemental = msg_5.get("vcp_supplemental_decoded", {})
+        sequencing = msg_5.get("vcp_sequencing_decoded", {})
+        vel_res = msg_5.get("doppler_velocity_resolution", 0)
+        pw = msg_5.get("pulse_width", 0)
+        return {
+            "scan_name": f"VCP-{msg_5['pattern_number']}",
+            "dynamic_scan_type": _get_dynamic_scan_type(supplemental),
+            "mpda_vcp": supplemental.get("mpda_vcp", False),
+            "base_tilt_vcp": supplemental.get("base_tilt_vcp", False),
+            "num_base_tilts": supplemental.get("num_base_tilts", 0),
+            "vcp_truncated": sequencing.get("truncated_vcp", False),
+            "vcp_sequence_active": sequencing.get("sequence_active", False),
+            "number_elevation_cuts": msg_5.get("number_elevation_cuts", 0),
+            "doppler_velocity_resolution": 0.5 if vel_res == 2 else 1.0,
+            "vcp_pulse_width": "short" if pw == 2 else "long" if pw == 4 else pw,
+        }
+
+    @staticmethod
+    def _attrs_from_msg_2(msg_2):
+        """Extract root attributes from MSG_2 (RDA Status)."""
+        flags = msg_2.get("rda_scan_data_flags_decoded", {})
+        return {
+            "avset_enabled": flags.get("avset_enabled", False),
+            "ebc_enabled": flags.get("ebc_enabled", False),
+            "super_res_status": msg_2.get("super_res_status", 0),
+            "rda_build_number": msg_2.get("rda_build_number", 0),
+            "operational_mode": msg_2.get("operational_mode", 0),
+        }
 
 
 class NexradLevel2BackendEntrypoint(BackendEntrypoint):

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1154,7 +1154,11 @@ _CHANNEL_CONFIGS = {
 
 
 def _assign_sweep_attrs(dtree, elev_data):
-    """Inject per-sweep attrs from MSG_5_ELEV data onto sweep nodes."""
+    """Inject per-sweep attrs from MSG_5_ELEV data onto sweep nodes.
+
+    The elev_data list index aligns with sweep_{i} naming because both
+    are ordered by elevation cut index in the VCP definition.
+    """
     if not elev_data:
         return
     for i, elev in enumerate(elev_data):
@@ -1180,7 +1184,10 @@ def _assign_sweep_attrs(dtree, elev_data):
 
 
 def _get_dynamic_scan_type(supplemental):
-    """Derive dynamic scan type string from VCP supplemental decoded dict."""
+    """Derive dynamic scan type string from VCP supplemental decoded dict.
+
+    SAILS and MRLE are mutually exclusive per ICD Note 16.
+    """
     if supplemental.get("sails_vcp"):
         n = supplemental.get("num_sails_cuts", 0)
         return f"SAILS x {n}" if n else "SAILS"
@@ -1862,7 +1869,8 @@ class NexradLevel2Store(AbstractDataStore):
             "vcp_sequence_active": sequencing.get("sequence_active", False),
             "number_elevation_cuts": msg_5.get("number_elevation_cuts", 0),
             "doppler_velocity_resolution": 0.5 if vel_res == 2 else 1.0,
-            "vcp_pulse_width": "short" if pw == 2 else "long" if pw == 4 else pw,
+            # ICD MSG_5 HW6: 2=short, 4=long
+            "vcp_pulse_width": "short" if pw == 2 else "long" if pw == 4 else str(pw),
         }
 
     @staticmethod
@@ -2081,8 +2089,16 @@ def open_nexradlevel2_datatree(
                 "cannot be decoded without it."
             )
 
-    incomplete = set()
-    elev_data = []
+    # Single metadata read for sweep count, completeness, and elevation data
+    with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
+        act_sweeps = len(nex.msg_31_data_header)
+        incomplete = nex.incomplete_sweeps
+        if nex.msg_5:
+            exp_sweeps = nex.msg_5["number_elevation_cuts"]
+            elev_data = nex.msg_5.get("elevation_data", [])
+        else:
+            exp_sweeps = 0
+            elev_data = []
 
     if isinstance(sweep, str):
         sweep = NodePath(sweep).name
@@ -2099,24 +2115,9 @@ def open_nexradlevel2_datatree(
                 "Invalid type in 'sweep' list. Expected integers (e.g., [0, 1, 2]) or strings (e.g. [/sweep_0, sweep_1])."
             )
     else:
-        with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
-            # Expected number of elevation cuts from the VCP definition
-            if nex.msg_5:
-                exp_sweeps = nex.msg_5["number_elevation_cuts"]
-                elev_data = nex.msg_5.get("elevation_data", [])
-            else:
-                exp_sweeps = 0
-            # Actual number of sweeps recorded in the file
-            act_sweeps = len(nex.msg_31_data_header)
-            # Check for AVSET mode: If AVSET was active, the actual number of sweeps (act_sweeps)
-            # will be fewer than the expected number (exp_sweeps), as higher elevations were skipped.
-            # More info https://www.test.roc.noaa.gov/radar-techniques/avset.php
-            # https://www.test.roc.noaa.gov/public-documents/engineering-branch/new-technology/misc/avset/AVSET_AMS_RADAR_CONF_Final.pdf
-            if exp_sweeps > act_sweeps:
-                # Adjust nsweeps to the actual number of recorded sweeps
-                exp_sweeps = act_sweeps
-
-            incomplete = nex.incomplete_sweeps
+        # Check for AVSET mode: actual sweeps may be fewer than VCP definition
+        if exp_sweeps > act_sweeps:
+            exp_sweeps = act_sweeps
 
         if incomplete_sweep == "drop":
             sweeps = [f"sweep_{i}" for i in range(act_sweeps) if i not in incomplete]
@@ -2142,19 +2143,6 @@ def open_nexradlevel2_datatree(
                 f"Invalid incomplete_sweep={incomplete_sweep!r}. "
                 "Expected 'drop' or 'pad'."
             )
-
-    # For pad mode with user-specified sweeps, read incomplete set
-    if incomplete_sweep == "pad" and not incomplete:
-        with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
-            incomplete = nex.incomplete_sweeps
-            if not elev_data and nex.msg_5:
-                elev_data = nex.msg_5.get("elevation_data", [])
-
-    # Read elevation metadata for per-sweep attrs if not yet available
-    if not elev_data:
-        with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
-            if nex.msg_5:
-                elev_data = nex.msg_5.get("elevation_data", [])
 
     sweep_dict = open_sweeps_as_dict(
         filename_or_obj=filename_or_obj,

--- a/xradar/io/export/cfradial1.py
+++ b/xradar/io/export/cfradial1.py
@@ -131,6 +131,11 @@ def _variable_mapper(dtree, dim0=None):
 
             data = data.drop_vars(["x", "y", "z"], errors="ignore")
 
+            # Strip per-sweep attrs that may vary across sweeps (e.g.
+            # NEXRAD ICD waveform_type, super_resolution) to avoid
+            # merge conflicts in combine_by_coords below.
+            data.attrs = {}
+
             # Convert to a dataset and append to the list
             sweep_datasets.append(data)
 


### PR DESCRIPTION
## Summary

Expose NEXRAD ICD scan metadata from Messages 2, 5, and 31 as FM301-compliant user-defined attributes on the DataTree. This gives downstream consumers direct access to dynamic scan flags rather than inferring them from elevation-angle patterns.

### Root-level attributes (from MSG_5 VCP definition)
- **`dynamic_scan_type`**: `"SAILS x 3"` / `"MRLE x 4"` / `"standard"` — derived from HW 10 supplemental data (SAILS and MRLE are mutually exclusive per ICD Note 16)
- **`mpda_vcp`**, **`base_tilt_vcp`**, **`num_base_tilts`** — additional VCP modification flags
- **`vcp_truncated`**, **`vcp_sequence_active`** — VCP sequencing info from HW 9
- **`number_elevation_cuts`** — VCP-defined count; **`actual_elevation_cuts`** — sweeps in the file. When \`actual < expected\` and \`avset_enabled=True\`, AVSET terminated the volume early
- **`doppler_velocity_resolution`**, **`vcp_pulse_width`** — VCP-level waveform parameters

### Root-level attributes (from MSG_2 RDA Status)
- **`avset_enabled`** — independent of scan type (different ICD message)
- **`ebc_enabled`** — Elevation Bias Correction status
- **`super_res_status`**, **`rda_build_number`**, **`operational_mode`** — RDA operational info

### Per-sweep attributes (from MSG_5_ELEV, injected after DataTree construction)
- **`waveform_type`** — human-readable: \`contiguous_surveillance\`, \`contiguous_doppler\`, \`batch\`, \`staggered_pulse_pair\`
- **`channel_config`** — \`constant_phase\`, \`random_phase\`, \`sz2_phase_coding\`
- **`super_resolution`** — super res control bits per elevation cut
- **`sails_cut`**, **`sails_sequence_number`**, **`mrle_cut`**, **`mrle_sequence_number`**, **`mpda_cut`**, **`base_tilt_cut`** — per-elevation ICD Note 17 flags

### ICD parsing
- Parse MSG_5 HW 9-10 (VCP sequencing + supplemental) replacing 10-byte \`spare\` with structured fields
- Parse MSG_2 HW 1-14 (RDA Status Data) payload — previously only headers were stored
- Rename MSG_5_ELEV \`spare_1\` → \`supplemental_data\` (E15) for per-elevation SAILS/MRLE identification
- Four bit-decoding helpers: \`decode_vcp_sequencing\`, \`decode_vcp_supplemental\`, \`decode_elevation_supplemental\`, \`decode_rda_scan_data_flags\`

### CfRadial1 export fix
- Strip per-sweep attrs before \`combine_by_coords\` to prevent merge conflicts when attrs like \`waveform_type\` differ across sweeps
- Update round-trip test to check subset equality (backend-specific attrs don't survive generic round-trip)

### Design decisions
- All root attrs are **FM301 §2.1.6 user-defined metadata** — none map to CfRadial2 standard groups (that will be a follow-up PR for \`/radar_calibration\`)
- Per-sweep metadata stored as \`.attrs\` (not \`data_vars\`) to keep sweep datasets clean
- Single \`NEXRADLevel2File\` open for metadata instead of multiple conditional opens

Closes #338

## Test plan

- [x] 92 NEXRAD tests pass + 4 CfRadial transform tests pass (96 total)
- [x] Unit tests for all 4 bit decoders with full-dict equality assertions
- [x] MSG_2 integration test + backward compat for missing MSG_2
- [x] Root attrs validated from real NEXRAD file (KATX VCP-11)
- [x] Per-sweep attrs validated with known values (VCP-11 sweep_0)
- [x] \`_get_dynamic_scan_type\` helper tested for all branches
- [x] CfRadial1 round-trip export tested
- [x] Validated against real S3 files: SAILS×2, SAILS×1+AVSET, base tilt+AVSET, standard VCP-35
- [x] black and ruff clean
