### PR TITLE
FIX: allow passing inherit parameter to apply_to_sweeps

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -10,6 +10,7 @@
 * ADD: ``incomplete_sweep`` parameter (``"drop"``/``"pad"``) to ``open_nexradlevel2_datatree`` for handling incomplete sweeps in partial volume data ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * ADD: Notebook example for streaming NEXRAD Level 2 chunks from S3 (``nexrad_read_chunks.ipynb``) ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * ADD: Comprehensive test suite for chunk list-input and incomplete sweep handling ({pull}`332`) by [@aladinor](https://github.com/aladinor)
+* FIX: Allow passing ``inherit`` parameter to ``apply_to_sweeps`` / ``map_over_sweeps`` to control coordinate inheritance from root node ({issue}`343`, {pull}`344`) by [@aladinor](https://github.com/aladinor)
 
 ## 0.11.1 (2026-02-03)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,14 @@ def file_or_filelike(request):
 
 
 @pytest.fixture(scope="session")
+def cfradial1_sgp_dtree():
+    import xradar as xd
+
+    filename = DATASETS.fetch("sample_sgp_data.nc")
+    return xd.io.open_cfradial1_datatree(filename)
+
+
+@pytest.fixture(scope="session")
 def cfradial1_file(tmp_path_factory):
     return DATASETS.fetch("cfrad.20080604_002217_000_SPOL_v36_SUR.nc")
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -325,37 +325,33 @@ def test_apply_to_sweeps():
         util.apply_to_sweeps(dtree, error_function)
 
 
-def test_apply_to_sweeps_inherit_false():
+def test_apply_to_sweeps_inherit_false(cfradial1_sgp_dtree):
     """inherit=False prevents root coords from leaking onto sweeps."""
-    filename = DATASETS.fetch("sample_sgp_data.nc")
-    dtree = io.open_cfradial1_datatree(filename)
-
     root_coords = {"latitude", "longitude", "altitude"}
 
     def identity(ds):
         return ds
 
     # Default (inherit="all_coords"): root coords appear on sweeps
-    result_default = util.apply_to_sweeps(dtree, identity)
+    result_default = util.apply_to_sweeps(cfradial1_sgp_dtree, identity)
     sweep_ds = result_default["sweep_0"].to_dataset(inherit=False)
     inherited = root_coords & set(sweep_ds.coords)
     assert inherited, "Default should inherit root coords"
 
     # inherit=False: root coords stay on root only
-    result_no_inherit = util.apply_to_sweeps(dtree, identity, inherit=False)
+    result_no_inherit = util.apply_to_sweeps(
+        cfradial1_sgp_dtree, identity, inherit=False
+    )
     sweep_ds = result_no_inherit["sweep_0"].to_dataset(inherit=False)
     leaked = root_coords & (set(sweep_ds.coords) | set(sweep_ds.data_vars))
     assert not leaked, f"inherit=False should not leak root coords: {leaked}"
 
 
-def test_apply_to_sweeps_inherit_via_map_over_sweeps():
+def test_apply_to_sweeps_inherit_via_map_over_sweeps(cfradial1_sgp_dtree):
     """inherit parameter works through map_over_sweeps accessor."""
-    filename = DATASETS.fetch("sample_sgp_data.nc")
-    dtree = io.open_cfradial1_datatree(filename)
-
     root_coords = {"latitude", "longitude", "altitude"}
 
-    result = dtree.xradar.map_over_sweeps(lambda ds: ds, inherit=False)
+    result = cfradial1_sgp_dtree.xradar.map_over_sweeps(lambda ds: ds, inherit=False)
     sweep_ds = result["sweep_0"].to_dataset(inherit=False)
     leaked = root_coords & (set(sweep_ds.coords) | set(sweep_ds.data_vars))
     assert not leaked, f"inherit=False via accessor should not leak: {leaked}"

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -325,6 +325,42 @@ def test_apply_to_sweeps():
         util.apply_to_sweeps(dtree, error_function)
 
 
+def test_apply_to_sweeps_inherit_false():
+    """inherit=False prevents root coords from leaking onto sweeps."""
+    filename = DATASETS.fetch("sample_sgp_data.nc")
+    dtree = io.open_cfradial1_datatree(filename)
+
+    root_coords = {"latitude", "longitude", "altitude"}
+
+    def identity(ds):
+        return ds
+
+    # Default (inherit="all_coords"): root coords appear on sweeps
+    result_default = util.apply_to_sweeps(dtree, identity)
+    sweep_ds = result_default["sweep_0"].to_dataset(inherit=False)
+    inherited = root_coords & set(sweep_ds.coords)
+    assert inherited, "Default should inherit root coords"
+
+    # inherit=False: root coords stay on root only
+    result_no_inherit = util.apply_to_sweeps(dtree, identity, inherit=False)
+    sweep_ds = result_no_inherit["sweep_0"].to_dataset(inherit=False)
+    leaked = root_coords & (set(sweep_ds.coords) | set(sweep_ds.data_vars))
+    assert not leaked, f"inherit=False should not leak root coords: {leaked}"
+
+
+def test_apply_to_sweeps_inherit_via_map_over_sweeps():
+    """inherit parameter works through map_over_sweeps accessor."""
+    filename = DATASETS.fetch("sample_sgp_data.nc")
+    dtree = io.open_cfradial1_datatree(filename)
+
+    root_coords = {"latitude", "longitude", "altitude"}
+
+    result = dtree.xradar.map_over_sweeps(lambda ds: ds, inherit=False)
+    sweep_ds = result["sweep_0"].to_dataset(inherit=False)
+    leaked = root_coords & (set(sweep_ds.coords) | set(sweep_ds.data_vars))
+    assert not leaked, f"inherit=False via accessor should not leak: {leaked}"
+
+
 def test_apply_to_volume():
     # Fetch the sample radar file
     filename = DATASETS.fetch("sample_sgp_data.nc")

--- a/xradar/util.py
+++ b/xradar/util.py
@@ -554,8 +554,15 @@ def apply_to_sweeps(dtree, func, *args, **kwargs):
     **kwargs : dict
         Additional keyword arguments to pass to the function.
         The ``inherit`` key, if present, is popped and forwarded to
-        ``DataTree.to_dataset()`` instead of *func*.  Defaults to
-        ``"all_coords"`` for backward compatibility.
+        :py:meth:`xarray.DataTree.to_dataset` instead of *func*.
+        Accepted values (see xarray docs for details):
+
+        - ``True`` or ``"indexes"``: inherit only indexed coordinates.
+        - ``"all_coords"``: inherit all coordinates, including
+          non-index coordinates.
+        - ``False``: only include coordinates defined at the sweep node.
+
+        Defaults to ``"all_coords"`` for backward compatibility.
 
     Returns
     -------

--- a/xradar/util.py
+++ b/xradar/util.py
@@ -553,12 +553,17 @@ def apply_to_sweeps(dtree, func, *args, **kwargs):
         Additional positional arguments to pass to the function.
     **kwargs : dict
         Additional keyword arguments to pass to the function.
+        The ``inherit`` key, if present, is popped and forwarded to
+        ``DataTree.to_dataset()`` instead of *func*.  Defaults to
+        ``"all_coords"`` for backward compatibility.
 
     Returns
     -------
     xarray.DataTree
         A new DataTree object with the function applied to all sweeps.
     """
+    inherit = kwargs.pop("inherit", "all_coords")
+
     # Create a new tree dictionary
     tree = {"/": dtree.ds}  # Start with the root Dataset
 
@@ -569,7 +574,7 @@ def apply_to_sweeps(dtree, func, *args, **kwargs):
     tree.update(
         {
             node.path: func(
-                dtree[node.path].to_dataset(inherit="all_coords"), *args, **kwargs
+                dtree[node.path].to_dataset(inherit=inherit), *args, **kwargs
             )
             for node in dtree.match("sweep*").subtree
             if node.path.startswith("/sweep")


### PR DESCRIPTION
## Summary

- Pop `inherit` from `kwargs` in `apply_to_sweeps` before forwarding to `func`, defaulting to `"all_coords"` for backward compatibility
- This lets callers control whether root coords (lat/lon/alt) are inherited onto sweep datasets via `to_dataset(inherit=...)`
- Using `inherit=False` prevents station coords from leaking onto sweeps after `map_over_sweeps`, preserving the root-only storage from PR #337

Closes #343

## Test plan

- [x] `test_apply_to_sweeps_inherit_false` — verifies `inherit=False` prevents root coord leakage
- [x] `test_apply_to_sweeps_inherit_via_map_over_sweeps` — verifies it works through the accessor
- [x] Existing `test_apply_to_sweeps` still passes (backward compatible)
- [x] All 130 util + accessor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)