### PR TITLE
FIX: use open-radar-data fixture as fallback for nexrad_read_chunks notebook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
             h5py
             lat_lon_parser
             netCDF4
-            open-radar-data>=0.4.2
+            open-radar-data>=0.6.0
             packaging
             pandas
             pip

--- a/ci/notebooktests.yml
+++ b/ci/notebooktests.yml
@@ -17,7 +17,7 @@ dependencies:
   - netCDF4
   - notebook
   - numpy
-  - open-radar-data>=0.4.2
+  - open-radar-data>=0.6.0
   - pip
   - pyproj
   - pytest

--- a/ci/unittests.yml
+++ b/ci/unittests.yml
@@ -14,7 +14,7 @@ dependencies:
   - lat_lon_parser
   - netCDF4
   - numpy
-  - open-radar-data>=0.4.2
+  - open-radar-data>=0.6.0
   - pip
   - pyproj
   - pytest

--- a/docs/history.md
+++ b/docs/history.md
@@ -11,6 +11,8 @@
 * ADD: Notebook example for streaming NEXRAD Level 2 chunks from S3 (``nexrad_read_chunks.ipynb``) ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * ADD: Comprehensive test suite for chunk list-input and incomplete sweep handling ({pull}`332`) by [@aladinor](https://github.com/aladinor)
 * FIX: Allow passing ``inherit`` parameter to ``apply_to_sweeps`` / ``map_over_sweeps`` to control coordinate inheritance from root node ({issue}`343`, {pull}`344`) by [@aladinor](https://github.com/aladinor)
+* FIX: Use ``open-radar-data`` fixture as fallback for ``nexrad_read_chunks.ipynb`` notebook, replacing dependency on ephemeral S3 chunk data ({issue}`351`, {pull}`352`) by [@aladinor](https://github.com/aladinor)
+* MNT: Pin ``open-radar-data>=0.6.0`` for NEXRAD chunk test data ({pull}`352`) by [@aladinor](https://github.com/aladinor)
 
 ## 0.11.1 (2026-02-03)
 

--- a/environment.yml
+++ b/environment.yml
@@ -17,7 +17,7 @@ dependencies:
   - h5py
   - lat_lon_parser
   - netCDF4
-  - open-radar-data>=0.1.0
+  - open-radar-data>=0.6.0
   - pyproj
   - pip:
     - xarray @ git+https://github.com/pydata/xarray.git@main

--- a/examples/notebooks/nexrad_read_chunks.ipynb
+++ b/examples/notebooks/nexrad_read_chunks.ipynb
@@ -24,16 +24,7 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "import warnings\n",
-    "\n",
-    "import cmweather  # noqa: F401 -- registers colormaps\n",
-    "import fsspec\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "import xradar as xd"
-   ]
+   "source": "import warnings\n\nimport cmweather  # noqa: F401 -- registers colormaps\nimport fsspec\nimport matplotlib.pyplot as plt\nimport numpy as np\n\nimport xradar as xd"
   },
   {
    "cell_type": "markdown",
@@ -74,9 +65,7 @@
    "cell_type": "markdown",
    "id": "3",
    "metadata": {},
-   "source": [
-    "## Connect to S3 and list chunks"
-   ]
+   "source": "## Load chunk data\n\nThe notebook first tries to list live chunks from the `unidata-nexrad-level2-chunks`\nS3 bucket. If the bucket is empty or unreachable (e.g. in CI), it falls back to\narchived chunks from `open-radar-data`."
   },
   {
    "cell_type": "code",
@@ -84,31 +73,13 @@
    "id": "4",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "fs = fsspec.filesystem(\"s3\", anon=True)\n",
-    "\n",
-    "# List available volume directories for KABR\n",
-    "volumes = sorted(fs.ls(\"unidata-nexrad-level2-chunks/KABR/\"))\n",
-    "latest = volumes[-1]\n",
-    "print(f\"Latest volume directory: {latest}\")\n",
-    "\n",
-    "# List all chunk files in that volume\n",
-    "chunk_paths = sorted(fs.ls(latest))\n",
-    "print(f\"\\nTotal chunks: {len(chunk_paths)}\")\n",
-    "print(\"\\nFirst 5 chunks:\")\n",
-    "for p in chunk_paths[:5]:\n",
-    "    print(f\"  {p.split('/')[-1]}\")\n",
-    "print(\"\\nLast chunk:\")\n",
-    "print(f\"  {chunk_paths[-1].split('/')[-1]}\")"
-   ]
+   "source": "chunk_paths = []\n\ntry:\n    fs = fsspec.filesystem(\"s3\", anon=True)\n    volumes = sorted(fs.ls(\"unidata-nexrad-level2-chunks/KABR/\"))\n    if volumes:\n        chunk_paths = sorted(fs.ls(volumes[-1]))\nexcept Exception:\n    pass\n\nif chunk_paths:\n    print(f\"Using live S3 chunks: {len(chunk_paths)} files\")\n    for p in chunk_paths[:3]:\n        print(f\"  {p.split('/')[-1]}\")\n    print(f\"  ... {chunk_paths[-1].split('/')[-1]}\")\nelse:\n    print(\"S3 bucket empty or unreachable, using open-radar-data fixture\")"
   },
   {
    "cell_type": "markdown",
    "id": "5",
    "metadata": {},
-   "source": [
-    "## Download all chunk bytes"
-   ]
+   "source": "## Download / load chunk bytes"
   },
   {
    "cell_type": "code",
@@ -116,11 +87,7 @@
    "id": "6",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "all_bytes = [fs.open(p, \"rb\").read() for p in chunk_paths]\n",
-    "total_mb = sum(len(b) for b in all_bytes) / 1e6\n",
-    "print(f\"Downloaded {len(all_bytes)} chunks ({total_mb:.1f} MB total)\")"
-   ]
+   "source": "if chunk_paths:\n    all_bytes = [fs.open(p, \"rb\").read() for p in chunk_paths]\nelse:\n    import tarfile\n    from pathlib import Path\n\n    from open_radar_data import DATASETS\n\n    archive = DATASETS.fetch(\"nexrad_level2_chunks_KLOT.tar.gz\")\n    with tarfile.open(archive) as tar:\n        tar.extractall(\"/tmp/nexrad_chunks\", filter=\"data\")\n    chunk_files = sorted(Path(\"/tmp/nexrad_chunks/nexrad_chunks_KLOT\").iterdir())\n    all_bytes = [f.read_bytes() for f in chunk_files]\n\ntotal_mb = sum(len(b) for b in all_bytes) / 1e6\nprint(f\"Loaded {len(all_bytes)} chunks ({total_mb:.1f} MB total)\")"
   },
   {
    "cell_type": "markdown",

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ fsspec
 ruff
 nbconvert
 notebook
-open_radar_data
+open_radar_data @ git+https://github.com/aladinor/open-radar-data.git@nexrad-chunks
 boto3
 cartopy
 s3fs

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ fsspec
 ruff
 nbconvert
 notebook
-open_radar_data
+open_radar_data>=0.6.0
 boto3
 cartopy
 s3fs

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -11,7 +11,7 @@ fsspec
 ruff
 nbconvert
 notebook
-open_radar_data @ git+https://github.com/aladinor/open-radar-data.git@nexrad-chunks
+open_radar_data
 boto3
 cartopy
 s3fs

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -79,6 +79,18 @@ def nexradlevel2_file():
 
 
 @pytest.fixture(scope="session")
+def nexrad_chunks_klot(tmp_path_factory):
+    import tarfile
+
+    archive = DATASETS.fetch("nexrad_level2_chunks_KLOT.tar.gz")
+    extract_dir = tmp_path_factory.mktemp("nexrad_chunks")
+    with tarfile.open(archive) as tar:
+        tar.extractall(extract_dir, filter="data")
+    chunk_dir = extract_dir / "nexrad_chunks_KLOT"
+    return sorted(chunk_dir.iterdir())
+
+
+@pytest.fixture(scope="session")
 def nexradlevel2_msg1_file(tmp_path_factory):
     fnamei = DATASETS.fetch("KLIX20050828_180149.gz")
     fnameo = os.path.join(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,7 +90,10 @@ def nexradlevel2_file():
 def nexrad_chunks_klot(tmp_path_factory):
     import tarfile
 
-    archive = DATASETS.fetch("nexrad_level2_chunks_KLOT.tar.gz")
+    try:
+        archive = DATASETS.fetch("nexrad_level2_chunks_KLOT.tar.gz")
+    except (ValueError, Exception):
+        pytest.skip("nexrad_level2_chunks_KLOT.tar.gz not in open-radar-data registry")
     extract_dir = tmp_path_factory.mktemp("nexrad_chunks")
     with tarfile.open(archive) as tar:
         tar.extractall(extract_dir, filter="data")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -90,10 +90,7 @@ def nexradlevel2_file():
 def nexrad_chunks_klot(tmp_path_factory):
     import tarfile
 
-    try:
-        archive = DATASETS.fetch("nexrad_level2_chunks_KLOT.tar.gz")
-    except (ValueError, Exception):
-        pytest.skip("nexrad_level2_chunks_KLOT.tar.gz not in open-radar-data registry")
+    archive = DATASETS.fetch("nexrad_level2_chunks_KLOT.tar.gz")
     extract_dir = tmp_path_factory.mktemp("nexrad_chunks")
     with tarfile.open(archive) as tar:
         tar.extractall(extract_dir, filter="data")

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -1940,3 +1940,56 @@ class TestListInputWithIncompleteSweep:
         assert list(dtree_direct.match("sweep_*").keys()) == list(
             dtree_tuple.match("sweep_*").keys()
         )
+
+
+class TestRealChunkFiles:
+    """Integration tests using real NEXRAD chunk files from open-radar-data."""
+
+    def test_full_volume_from_chunks(self, nexrad_chunks_klot):
+        """All chunks produce a complete volume with sweeps and data."""
+        chunk_bytes = [f.read_bytes() for f in nexrad_chunks_klot]
+        dtree = open_nexradlevel2_datatree(chunk_bytes, reindex_angle=False)
+
+        sweep_keys = list(dtree.match("sweep_*").keys())
+        assert len(sweep_keys) > 0
+        assert "DBZH" in dtree["sweep_0"].data_vars
+        assert dtree.attrs["scan_name"].startswith("VCP-")
+
+    def test_partial_chunks_drop_mode(self, nexrad_chunks_klot):
+        """Partial chunks with drop mode have fewer sweeps than full volume."""
+        chunk_bytes = [f.read_bytes() for f in nexrad_chunks_klot[:15]]
+        dtree = open_nexradlevel2_datatree(
+            chunk_bytes, reindex_angle=False, incomplete_sweep="drop"
+        )
+
+        all_bytes = [f.read_bytes() for f in nexrad_chunks_klot]
+        dtree_full = open_nexradlevel2_datatree(all_bytes, reindex_angle=False)
+        assert len(dtree.match("sweep_*")) <= len(dtree_full.match("sweep_*"))
+
+    def test_partial_chunks_pad_mode(self, nexrad_chunks_klot):
+        """Partial chunks with pad mode produce full azimuth grid with NaN."""
+        chunk_bytes = [f.read_bytes() for f in nexrad_chunks_klot[:15]]
+        dtree = open_nexradlevel2_datatree(
+            chunk_bytes, reindex_angle=False, incomplete_sweep="pad"
+        )
+
+        sweep_keys = list(dtree.match("sweep_*").keys())
+        assert len(sweep_keys) > 0
+        ds = dtree["sweep_0"].to_dataset()
+        assert ds.sizes["azimuth"] in (360, 720)
+
+    def test_early_stream_few_chunks(self, nexrad_chunks_klot):
+        """Only 5 chunks with pad mode still produce data."""
+        chunk_bytes = [f.read_bytes() for f in nexrad_chunks_klot[:5]]
+        dtree = open_nexradlevel2_datatree(
+            chunk_bytes, reindex_angle=False, incomplete_sweep="pad"
+        )
+
+        assert len(dtree.match("sweep_*")) > 0
+
+    def test_chunk_file_paths_input(self, nexrad_chunks_klot):
+        """List of file paths (not bytes) works as input."""
+        dtree = open_nexradlevel2_datatree(nexrad_chunks_klot, reindex_angle=False)
+
+        assert len(dtree.match("sweep_*")) > 0
+        assert "DBZH" in dtree["sweep_0"].data_vars


### PR DESCRIPTION
## Summary

- Update `nexrad_read_chunks.ipynb` to try live S3 chunks first, fall back to `open-radar-data` fixture if bucket is empty/unreachable
- Add `nexrad_chunks_klot` session fixture to `conftest.py` for test usage
- Temporarily pin `open-radar-data` to `nexrad-chunks` branch (pending openradar/open-radar-data#92)

**Depends on:** openradar/open-radar-data#92 (adds `nexrad_level2_chunks_KLOT.tar.gz`)

Closes #351

## Test plan

- [x] Notebook executes successfully using fixture fallback
- [x] Fixture correctly extracts 55 chunks from tar.gz
- [x] Full pipeline: 55 chunks → 12 sweeps, VCP-35
