### PR TITLE
REL: 0.12.0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -6,10 +6,13 @@
 * Kai Mühlbauer <kai.muehlbauer@uni-bonn.de>
 * Zachary Sherman <zsherman@anl.gov>
 
-## Contributors
+## Maintainers
 
 * Edouard Goudenhoofdt <edouard.goudenhoofdt@meteo.be>
-* Hamid Ali Syed <hamidsyed37@gmail.com>
 * Alfonso Ladino <alfonso8@illinois.edu>
+* Hamid Ali Syed <hamidsyed37@gmail.com>
+
+## Contributors
+
 * Bobby Jackson <rjackson@anl.gov>
 * Daniel Wolfensberger <daniel.wolfensberger@meteoswiss.ch>

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,7 +3,7 @@
 cff-version: 1.0.3
 message: If you use this software, please cite it using these metadata.
 # FIXME title as repository name might not be the best name, please make human readable
-title: 'openradar/xradar: xradar v0.11.0'
+title: 'openradar/xradar: xradar v0.12.0'
 doi: 10.5281/zenodo.7091737
 # FIXME splitting of full names is error prone, please check if given/family name are correct
 authors:
@@ -36,7 +36,7 @@ authors:
   affiliation: Federal Office of Meteorology and Climatology MeteoSwiss
   orcid: https://orcid.org/0009-0006-1419-0556
 
-version: 0.11.0
-date-released: 2026-01-12
+version: 0.12.0
+date-released: 2026-04-21
 repository-code: https://github.com/openradar/xradar
 license: MIT

--- a/ci/notebooktests.yml
+++ b/ci/notebooktests.yml
@@ -29,7 +29,7 @@ dependencies:
   - scipy
   - setuptools
   - pip:
-    - xarray @ git+https://github.com/pydata/xarray.git@main
+    - xarray >= 2026.4.0
   - xmltodict
   - boto3
   - arm_pyart

--- a/ci/unittests.yml
+++ b/ci/unittests.yml
@@ -25,5 +25,5 @@ dependencies:
   - scipy
   - setuptools
   - pip:
-    - xarray @ git+https://github.com/pydata/xarray.git@main
+    - xarray >= 2026.4.0
   - xmltodict

--- a/docs/history.md
+++ b/docs/history.md
@@ -4,7 +4,7 @@
 ## Development
 
 
-## 0.12.0 (2026-04-16)
+## 0.12.0 (2026-04-20)
 
 * MNT: Unpin xarray, require ``xarray >= 2026.4.0`` in ``requirements.txt``, ``environment.yml``, ``ci/unittests.yml``, and ``ci/notebooktests.yml`` by [@aladinor](https://github.com/aladinor)
 * MNT: Clarify contributor, team-member, and maintainer roles in the contributing guide, including the pathway to greater project involvement ({issue}`341`) by [@kmuehlbauer](https://github.com/kmuehlbauer), ({pull}`354`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/docs/history.md
+++ b/docs/history.md
@@ -3,7 +3,12 @@
 
 ## Development
 
+
+## 0.12.0 (2026-04-16)
+
+* MNT: Unpin xarray, require ``xarray >= 2026.4.0`` in ``requirements.txt``, ``environment.yml``, ``ci/unittests.yml``, and ``ci/notebooktests.yml`` by [@aladinor](https://github.com/aladinor)
 * MNT: Clarify contributor, team-member, and maintainer roles in the contributing guide, including the pathway to greater project involvement ({issue}`341`) by [@kmuehlbauer](https://github.com/kmuehlbauer), ({pull}`354`) by [@syedhamidali](https://github.com/syedhamidali)
+* FIX: ``open_nexradlevel2_datatree`` keeps sweeps with interior sweep-index gaps — derive sweep names from actual indices in ``nex.data`` instead of ``range(len(...))`` so upstream-dropped interior cuts (e.g. ``[0..9, 11]``) no longer raise ``KeyError`` ({issue}`361`, {pull}`362`) by [@aladinor](https://github.com/aladinor)
 * ADD: ``open_cfradial2_datatree`` reader with grouped CfRadial2 compatibility normalization for common FM301/CfRadial2 naming differences ({issue}`93`, {issue}`287`), ({pull}`349`) by [@syedhamidali](https://github.com/syedhamidali)
 * ENH: Move station coordinates (``latitude``, ``longitude``, ``altitude``) to root node as coordinates for DataTree coordinate inheritance ({issue}`331`, {pull}`333`) by [@aladinor](https://github.com/aladinor)
 * ENH: Add ``optional_groups`` parameter (default ``False``) to all ``open_*_datatree()`` functions to control inclusion of ``/radar_parameters``, ``/georeferencing_correction``, and ``/radar_calibration`` subgroups ({issue}`331`, {pull}`333`) by [@aladinor](https://github.com/aladinor)

--- a/docs/history.md
+++ b/docs/history.md
@@ -4,7 +4,7 @@
 ## Development
 
 
-## 0.12.0 (2026-04-20)
+## 0.12.0 (2026-04-21)
 
 * MNT: Unpin xarray, require ``xarray >= 2026.4.0`` in ``requirements.txt``, ``environment.yml``, ``ci/unittests.yml``, and ``ci/notebooktests.yml`` by [@aladinor](https://github.com/aladinor)
 * MNT: Clarify contributor, team-member, and maintainer roles in the contributing guide, including the pathway to greater project involvement ({issue}`341`) by [@kmuehlbauer](https://github.com/kmuehlbauer), ({pull}`354`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/docs/history.md
+++ b/docs/history.md
@@ -1,9 +1,5 @@
 # History
 
-
-## Development
-
-
 ## 0.12.0 (2026-04-21)
 
 * MNT: Unpin xarray, require ``xarray >= 2026.4.0`` in ``requirements.txt``, ``environment.yml``, ``ci/unittests.yml``, and ``ci/notebooktests.yml`` by [@aladinor](https://github.com/aladinor)

--- a/docs/history.md
+++ b/docs/history.md
@@ -3,6 +3,10 @@
 
 ## Development
 
+
+## 0.12.0 (2026-04-16)
+
+* MNT: Unpin xarray, require ``xarray >= 2026.4.0`` in ``requirements.txt``, ``environment.yml``, ``ci/unittests.yml``, and ``ci/notebooktests.yml`` by [@aladinor](https://github.com/aladinor)
 * ADD: ``open_cfradial2_datatree`` reader with grouped CfRadial2 compatibility normalization for common FM301/CfRadial2 naming differences ({issue}`93`, {issue}`287`) by [@syedhamidali](https://github.com/syedhamidali)
 * ENH: Move station coordinates (``latitude``, ``longitude``, ``altitude``) to root node as coordinates for DataTree coordinate inheritance ({issue}`331`, {pull}`333`) by [@aladinor](https://github.com/aladinor)
 * ENH: Add ``optional_groups`` parameter (default ``False``) to all ``open_*_datatree()`` functions to control inclusion of ``/radar_parameters``, ``/georeferencing_correction``, and ``/radar_calibration`` subgroups ({issue}`331`, {pull}`333`) by [@aladinor](https://github.com/aladinor)

--- a/environment.yml
+++ b/environment.yml
@@ -19,7 +19,7 @@ dependencies:
   - open-radar-data>=0.6.0
   - pyproj
   - pip:
-    - xarray @ git+https://github.com/pydata/xarray.git@main
+    - xarray >= 2026.4.0
   - xmltodict
   - cartopy
   - cmweather

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ netCDF4
 numpy
 pyproj
 scipy
-xarray @ git+https://github.com/pydata/xarray.git@main
+xarray >= 2026.4.0
 xmltodict


### PR DESCRIPTION
## Summary

xradar 0.12.0 release.

- Unpins xarray (pydata/xarray stable 2026.4.0 is now available) — requires `xarray >= 2026.4.0` across `requirements.txt`, `environment.yml`, `ci/unittests.yml`, `ci/notebooktests.yml`
- Stamps `## 0.12.0 (2026-04-16)` in `docs/history.md` and preserves an empty `## Development` section for the next cycle

Full changelog in `docs/history.md`. Highlights since 0.11.1: CfRadial2 reader (#349), station coords to root + `optional_groups` (#333), NEXRAD chunk/S3 streaming (#332), NEXRAD ICD scan metadata (#339), ODIM/GAMIC pickle fix (#345), `inherit` pass-through (#344), myst notebook migration (#348).

Closes #358

## Test plan

- [x] Full test suite passes locally against xarray 2026.4.0 (527 passed, 1 skipped)
- [x] `black --check` clean on tracked files
- [x] `ruff check` clean on tracked files
- [x] CI (unit + notebook) green on PR
- [x] Readthedocs preview renders

## Checklist

- [x] Changes are documented in `history.md`