### PR TITLE
FIX: open_nexradlevel2_datatree keeps sweeps with interior gaps

### DIFF
--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -1955,6 +1955,114 @@ class TestIncompleteSweepParameter:
             call_kwargs = mock_open_sweeps.call_args[1]
             assert call_kwargs["incomplete_sweeps"] == {1}
 
+    # Regression cases for openradar/xradar#361. When upstream drops
+    # an interior cut, nex.data retains surviving sweeps under their
+    # original indices (sparse keys). The sweep-name list must follow
+    # those keys, not range(len(...)).
+    @pytest.mark.parametrize(
+        "present_keys,incomplete,mode,expected",
+        [
+            # Single interior gap (the #361 case, reduced)
+            (
+                [0, 1, 2, 4],
+                set(),
+                "drop",
+                ["sweep_0", "sweep_1", "sweep_2", "sweep_4"],
+            ),
+            (
+                [0, 1, 2, 4],
+                set(),
+                "pad",
+                ["sweep_0", "sweep_1", "sweep_2", "sweep_4"],
+            ),
+            # Gap + incomplete: drop removes both, pad removes only gap
+            (
+                [0, 1, 2, 4],
+                {2},
+                "drop",
+                ["sweep_0", "sweep_1", "sweep_4"],
+            ),
+            (
+                [0, 1, 2, 4],
+                {2},
+                "pad",
+                ["sweep_0", "sweep_1", "sweep_2", "sweep_4"],
+            ),
+            # Multiple interior gaps
+            (
+                [0, 1, 3, 4, 7],
+                set(),
+                "drop",
+                ["sweep_0", "sweep_1", "sweep_3", "sweep_4", "sweep_7"],
+            ),
+            # Trailing gap (MSG_5 declared 4 cuts, parser got 3)
+            (
+                [0, 1, 2],
+                set(),
+                "drop",
+                ["sweep_0", "sweep_1", "sweep_2"],
+            ),
+            # Sparse keys from unsorted dict iteration order
+            (
+                [4, 0, 2, 1],
+                set(),
+                "drop",
+                ["sweep_0", "sweep_1", "sweep_2", "sweep_4"],
+            ),
+        ],
+        ids=[
+            "single-gap-drop",
+            "single-gap-pad",
+            "gap-and-incomplete-drop",
+            "gap-and-incomplete-pad",
+            "multiple-gaps-drop",
+            "trailing-gap-drop",
+            "unsorted-keys-drop",
+        ],
+    )
+    def test_interior_sweep_gap_uses_actual_keys(
+        self, present_keys, incomplete, mode, expected
+    ):
+        mock_nex = MagicMock()
+        mock_nex.msg_5 = {"number_elevation_cuts": max(present_keys) + 2}
+        mock_nex.data = {k: None for k in present_keys}
+        mock_nex.incomplete_sweeps = incomplete
+        mock_nex.__enter__ = MagicMock(return_value=mock_nex)
+        mock_nex.__exit__ = MagicMock(return_value=False)
+
+        dummy_ds = xarray.Dataset(
+            {
+                "time": (
+                    "azimuth",
+                    np.array(
+                        ["2024-01-01T00:00:00", "2024-01-01T00:01:00"],
+                        dtype="datetime64[ns]",
+                    ),
+                ),
+                "latitude": 35.0,
+                "longitude": -97.0,
+                "altitude": 300.0,
+            },
+        )
+        mock_sweep_dict = OrderedDict([("sweep_0", dummy_ds), ("sweep_1", dummy_ds)])
+
+        with (
+            patch(
+                "xradar.io.backends.nexrad_level2.NEXRADLevel2File",
+                return_value=mock_nex,
+            ),
+            patch(
+                "xradar.io.backends.nexrad_level2.open_sweeps_as_dict",
+                return_value=mock_sweep_dict,
+            ) as mock_open_sweeps,
+        ):
+            open_nexradlevel2_datatree(
+                b"\x00" * 100,
+                reindex_angle=False,
+                incomplete_sweep=mode,
+            )
+            assert mock_open_sweeps.call_args[1]["sweeps"] == expected
+
 
 class TestPadModeReindexing:
     """Tests for the pad-mode reindex pipeline using real NEXRAD data.

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -2091,8 +2091,14 @@ def open_nexradlevel2_datatree(
 
     # Single metadata read for sweep count, completeness, and elevation data
     with NEXRADLevel2File(filename_or_obj, loaddata=False) as nex:
-        act_sweeps = len(nex.msg_31_data_header)
+        # Reading incomplete_sweeps also triggers data_header parsing,
+        # populating nex.data. Must run before sorted(nex.data) below.
         incomplete = nex.incomplete_sweeps
+        # Use the sweep indices actually present, not range(len(...)):
+        # upstream-dropped interior sweeps leave sparse keys (e.g.
+        # [0..9, 11]) that would otherwise KeyError downstream. See #361.
+        present_keys = sorted(nex.data)
+        act_sweeps = len(present_keys)
         if nex.msg_5:
             exp_sweeps = nex.msg_5["number_elevation_cuts"]
             elev_data = nex.msg_5.get("elevation_data", [])
@@ -2120,7 +2126,7 @@ def open_nexradlevel2_datatree(
             exp_sweeps = act_sweeps
 
         if incomplete_sweep == "drop":
-            sweeps = [f"sweep_{i}" for i in range(act_sweeps) if i not in incomplete]
+            sweeps = [f"sweep_{i}" for i in present_keys if i not in incomplete]
             if incomplete:
                 warnings.warn(
                     f"Dropped {len(incomplete)} incomplete sweep(s): "
@@ -2137,7 +2143,7 @@ def open_nexradlevel2_datatree(
                 )
                 return DataTree()
         elif incomplete_sweep == "pad":
-            sweeps = [f"sweep_{i}" for i in range(act_sweeps)]
+            sweeps = [f"sweep_{i}" for i in present_keys]
         else:
             raise ValueError(
                 f"Invalid incomplete_sweep={incomplete_sweep!r}. "


### PR DESCRIPTION
## Summary

- Resolves #361.
- Derive sweep names from the actual sweep indices in `nex.data` (`sorted(nex.data)`) instead of `range(len(nex.msg_31_data_header))`. When NOAA's upstream pipeline drops an interior cut, the surviving sweeps keep their original labels (e.g. `[0..9, 11]` when cut 10 is missing); the old logic asked for the non-existent `sweep_10` and raised `KeyError` downstream, discarding the entire volume even though every present sweep contained valid data.
- Observed on ~0.7% of real NEXRAD Level-II volumes (573/84K across 14 months of KLOT on `s3://unidata-nexrad-level2/`).

## Implementation notes

- One-line change per branch in `open_nexradlevel2_datatree` (`xradar/io/backends/nexrad_level2.py`), applied to both `incomplete_sweep="drop"` and `incomplete_sweep="pad"`.
- `nex.incomplete_sweeps` is now read before `nex.data`, because it implicitly triggers `data_header` parsing which populates `nex.data`. Order matters; a comment documents this.
- AVSET-mode clamp (`if exp_sweeps > act_sweeps: exp_sweeps = act_sweeps`) is unchanged — `act_sweeps` remains the count of present sweeps.

## Test plan

- [x] New parametrized regression test in `TestIncompleteSweepParameter`, 7 cases:
  - single interior gap (drop + pad)
  - gap combined with an incomplete sweep (drop removes both; pad keeps the present one)
  - multiple interior gaps
  - trailing gap (MSG_5 declared N cuts, parser got fewer)
  - unsorted dict-iteration order (guards the `sorted()` call)
- [x] Full `tests/io/test_nexrad_level2.py` passes (104 tests).
- [x] `black --check` and `ruff check` clean on both modified files.
- [ ] End-to-end verification against one of the three public NODD paths in #361 (e.g. `s3://unidata-nexrad-level2/2021/11/04/KLOT/KLOT20211104_174202_V06`) — recommended before merge.