### PR TITLE
DOC: Add projection examples to Georeference notebook

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* DOC: Add projection comparison and cartopy map examples to ``Georeference_TargetCRS`` notebook by [@syedhamidali](https://github.com/syedhamidali)
 * ADD: India Meteorological Department (IMD) radar NetCDF reader (``IMDBackendEntrypoint``, ``open_imd_datatree``). IMD stores one sweep per file; ``open_imd_datatree`` accepts a single file or a list of files to assemble a multi-sweep volume ({issue}`368`, {pull}`367`) by [@syedhamidali](https://github.com/syedhamidali)
 * FIX: Preserve CfRadial metadata groups during CfRadial1/CfRadial2 transforms, allow ``to_cfradial2`` to reopen root-only ``engine="cfradial1"`` datasets, and normalize sweep metadata after ``map_over_sweeps`` operations so filtered volumes can be exported to CfRadial1 again ({issue}`254`, {issue}`322`) by [@syedhamidali](https://github.com/syedhamidali)
 * ENH: Expose ``target_crs`` on ``.xradar.georeference()`` accessor for DataArray, Dataset and DataTree, enabling reprojection via e.g. ``radar.xradar.georeference(target_crs=4326)`` ({issue}`243`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/docs/notebooks/Georeference_TargetCRS.md
+++ b/docs/notebooks/Georeference_TargetCRS.md
@@ -11,7 +11,7 @@ kernelspec:
   name: python3
 ---
 
-# Reproject Radar Coordinates via the Accessor
+# Reproject Radar Coordinates
 
 This notebook demonstrates the ``target_crs`` option now exposed on
 ``.xradar.georeference()`` for ``xarray.Dataset`` and ``xarray.DataTree``.
@@ -29,8 +29,10 @@ radar = radar.xradar.georeference(target_crs=4326)
 ## Imports
 
 ```{code-cell}
+import cartopy.crs as ccrs
 import cmweather  # noqa
 import matplotlib.pyplot as plt
+import pyproj
 from open_radar_data import DATASETS
 
 import xradar as xd
@@ -108,8 +110,6 @@ print("CRS:", crs.name, "| EPSG:", crs.to_epsg())
 ```
 
 ```{code-cell}
-import pyproj
-
 utm_crs = pyproj.CRS("EPSG:32633")  # UTM zone 33N (tweak for your radar site)
 radar_utm = radar.xradar.georeference(target_crs=utm_crs)
 sweep_utm = radar_utm["sweep_0"].to_dataset(inherit="all_coords")
@@ -124,8 +124,6 @@ print("CRS:", crs.name, "| EPSG:", crs.to_epsg())
 Once data is in a known CRS, hand it off to cartopy for map plotting.
 
 ```{code-cell}
-import cartopy.crs as ccrs
-
 radar_geo = radar.xradar.georeference(target_crs=4326)
 
 fig = plt.figure(figsize=(9, 8))
@@ -145,7 +143,91 @@ ax.set_title("Georeferenced PPI on PlateCarree map")
 
 +++
 
-## 5. Works on a single Dataset too
+## 5. Side-by-side comparison of projections
+
+Compare the same sweep in AEQD (meters), geographic (lon/lat), and
+Lambert Conformal Conic — a projection commonly used for mid-latitude
+weather maps.
+
+```{code-cell}
+fig, axes = plt.subplots(1, 3, figsize=(18, 5))
+
+# AEQD (default)
+radar_aeqd = radar.xradar.georeference()
+radar_aeqd["sweep_0"]["DBZ"].plot(
+    x="x", y="y", cmap="ChaseSpectral", ax=axes[0], add_colorbar=False,
+)
+axes[0].set_title("AEQD (meters)")
+axes[0].set_aspect("equal")
+
+# EPSG:4326 (lon/lat)
+radar_geo = radar.xradar.georeference(target_crs=4326)
+radar_geo["sweep_0"]["DBZ"].plot(
+    x="x", y="y", cmap="ChaseSpectral", ax=axes[1], add_colorbar=False,
+)
+axes[1].set_title("EPSG:4326 (lon/lat)")
+axes[1].set_xlabel("Longitude")
+axes[1].set_ylabel("Latitude")
+
+# Lambert Conformal Conic
+lcc_crs = pyproj.CRS.from_proj4(
+    "+proj=lcc +lat_1=30 +lat_2=60 +lat_0=39.5 +lon_0=-105 +datum=WGS84"
+)
+radar_lcc = radar.xradar.georeference(target_crs=lcc_crs)
+radar_lcc["sweep_0"]["DBZ"].plot(
+    x="x", y="y", cmap="ChaseSpectral", ax=axes[2], add_colorbar=False,
+)
+axes[2].set_title("Lambert Conformal Conic")
+axes[2].set_aspect("equal")
+
+fig.tight_layout()
+```
+
++++
+
+## 6. Radar data on different map projections
+
+The same georeferenced radar data rendered on four different cartopy map
+projections — coastlines and gridlines make the projection distortion visible.
+
+```{code-cell}
+import cartopy.feature as cfeature
+
+radar_geo = radar.xradar.georeference(target_crs=4326)
+lon0 = float(radar_geo.ds.coords["longitude"].values)
+lat0 = float(radar_geo.ds.coords["latitude"].values)
+
+projections = [
+    ("PlateCarree", ccrs.PlateCarree()),
+    ("Lambert Conformal", ccrs.LambertConformal(
+        central_longitude=lon0, central_latitude=lat0,
+    )),
+    ("Orthographic (globe)", ccrs.Orthographic(
+        central_longitude=lon0, central_latitude=lat0,
+    )),
+    ("Mercator", ccrs.Mercator(central_longitude=lon0)),
+]
+
+fig = plt.figure(figsize=(14, 12))
+
+for i, (name, proj) in enumerate(projections, 1):
+    ax = fig.add_subplot(2, 2, i, projection=proj)
+    radar_geo["sweep_0"]["DBZ"].plot(
+        x="x", y="y", cmap="ChaseSpectral",
+        transform=ccrs.PlateCarree(), ax=ax,
+        add_colorbar=False,
+    )
+    ax.coastlines()
+    ax.add_feature(cfeature.BORDERS, linewidth=0.5)
+    ax.gridlines(draw_labels=isinstance(proj, (ccrs.PlateCarree, ccrs.Mercator)))
+    ax.set_title(name)
+
+fig.tight_layout()
+```
+
++++
+
+## 7. Works on a single Dataset too
 
 The accessor is available on ``Dataset`` and ``DataArray`` as well, not just
 ``DataTree``.
@@ -158,7 +240,7 @@ ds_geo[["DBZ"]]
 
 +++
 
-## Notes
+## Summary
 
 * ``target_crs`` accepts anything ``pyproj.CRS(...)`` accepts: int
   [EPSG codes](https://epsg.io/), ``"EPSG:xxxx"`` strings, WKT, or


### PR DESCRIPTION
## Summary
- Adds side-by-side projection comparison (AEQD, EPSG:4326, Lambert Conformal Conic) to the `Georeference_TargetCRS` notebook
- Adds cartopy map examples showing the same radar data on four map projections (PlateCarree, Lambert Conformal, Orthographic, Mercator) with coastlines and borders
- Consolidates imports at the top of the notebook and updates history.md

Supersedes #369.