### PR TITLE
DOC: Add full-form descriptions for radar formats in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,19 +45,20 @@ Xradar is considered stable for the implemented readers and writers which have b
 ## Features
 
 ### Import/Export Capabilities
-* CfRadial1 and CfRadial2
-* ODIM_H5 format
+* CfRadial1 and CfRadial2 — CF/Radial convention for radar data
+* ODIM_H5 — OPERA Data Information Model (HDF5)
 
 ### Import-Only Capabilities
-* DataMet
-* Furuno
-* Gamic
-* HPL
-* Iris
-* MRR
-* NexradLevel2
-* Rainbow
-* UF
+* DataMet — DataMet weather radar
+* Furuno — Furuno weather radar
+* Gamic — GAMIC HDF5
+* HPL — Halo Photonics Lidar
+* IMD — India Meteorological Department
+* Iris — Vaisala IRIS/Sigmet
+* MRR — Micro Rain Radar (METEK)
+* NexradLevel2 — NEXRAD WSR-88D Level 2
+* Rainbow — LEONARDO (formerly Selex/Gematronik) Rainbow
+* UF — Universal Format
 
 ### Data Transformation and Alignment
 * Georeferencing (AEQD projection)

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Xradar is considered stable for the implemented readers and writers which have b
 
 ### Import/Export Capabilities
 * CfRadial1 and CfRadial2 — CF/Radial convention for radar data
-* ODIM_H5 — OPERA Data Information Model (HDF5)
+* ODIM_H5 — EUMETNET OPERA Data Information Model (HDF5)
 
 ### Import-Only Capabilities
 * DataMet — DataMet weather radar

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Xradar is considered stable for the implemented readers and writers which have b
 * [MRR](https://metek.de/product/mrr-pro/) — Micro Rain Radar (METEK)
 * [NexradLevel2](https://www.ncei.noaa.gov/products/radar/next-generation-weather-radar) — NEXRAD WSR-88D Level 2
 * [Rainbow](https://www.leonardo.com/en/products/meteor-family) — LEONARDO (formerly Selex/Gematronik) Rainbow
-* UF — Universal Format
+* [UF](https://journals.ametsoc.org/view/journals/bams/61/11/1520-0477-61_11_1401.xml) — Universal Format
 
 ### Data Transformation and Alignment
 * Georeferencing (AEQD projection)

--- a/README.md
+++ b/README.md
@@ -45,19 +45,19 @@ Xradar is considered stable for the implemented readers and writers which have b
 ## Features
 
 ### Import/Export Capabilities
-* CfRadial1 and CfRadial2 — CF/Radial convention for radar data
-* ODIM_H5 — EUMETNET OPERA Data Information Model (HDF5)
+* [CfRadial1 and CfRadial2](https://github.com/NCAR/CfRadial) — CF/Radial convention for radar data
+* [ODIM_H5](https://www.eumetnet.eu/activities/observations-programme/current-activities/opera/) — EUMETNET OPERA Data Information Model (HDF5)
 
 ### Import-Only Capabilities
 * DataMet — DataMet weather radar
-* Furuno — Furuno weather radar
-* Gamic — GAMIC HDF5
-* HPL — Halo Photonics Lidar
-* IMD — India Meteorological Department
-* Iris — Vaisala IRIS/Sigmet
-* MRR — Micro Rain Radar (METEK)
-* NexradLevel2 — NEXRAD WSR-88D Level 2
-* Rainbow — LEONARDO (formerly Selex/Gematronik) Rainbow
+* [Furuno](https://www.furuno.com/en/products/weather-radar/) — Furuno weather radar
+* [Gamic](https://gamic.com/) — GAMIC HDF5
+* [HPL](https://hfreval.com/) — Halo Photonics Lidar
+* [IMD](https://mausam.imd.gov.in/) — India Meteorological Department
+* [Iris](https://www.vaisala.com/en/products/weather-environmental-sensors/thunderstorm-and-weather-radars) — Vaisala IRIS/Sigmet
+* [MRR](https://metek.de/product/mrr-pro/) — Micro Rain Radar (METEK)
+* [NexradLevel2](https://www.ncei.noaa.gov/products/radar/next-generation-weather-radar) — NEXRAD WSR-88D Level 2
+* [Rainbow](https://www.leonardo.com/en/products/meteor-family) — LEONARDO (formerly Selex/Gematronik) Rainbow
 * UF — Universal Format
 
 ### Data Transformation and Alignment

--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* DOC: Add full-form descriptions for all supported radar formats in README.md by [@syedhamidali](https://github.com/syedhamidali)
 * ADD: India Meteorological Department (IMD) radar NetCDF reader (``IMDBackendEntrypoint``, ``open_imd_datatree``). IMD stores one sweep per file; ``open_imd_datatree`` accepts a single file or a list of files to assemble a multi-sweep volume ({issue}`368`, {pull}`367`) by [@syedhamidali](https://github.com/syedhamidali)
 * FIX: Preserve CfRadial metadata groups during CfRadial1/CfRadial2 transforms, allow ``to_cfradial2`` to reopen root-only ``engine="cfradial1"`` datasets, and normalize sweep metadata after ``map_over_sweeps`` operations so filtered volumes can be exported to CfRadial1 again ({issue}`254`, {issue}`322`) by [@syedhamidali](https://github.com/syedhamidali)
 * ENH: Expose ``target_crs`` on ``.xradar.georeference()`` accessor for DataArray, Dataset and DataTree, enabling reprojection via e.g. ``radar.xradar.georeference(target_crs=4326)`` ({issue}`243`) by [@syedhamidali](https://github.com/syedhamidali)


### PR DESCRIPTION
## Summary
- Adds full-form descriptions for all supported radar format acronyms in the README (e.g., ODIM_H5 → OPERA Data Information Model, HPL → Halo Photonics Lidar, IMD → India Meteorological Department, etc.)
- Updates history.md with the DOC entry

## Test plan
- [ ] README renders correctly on GitHub