### PR TITLE
FIX: open_store_coordinates handles interior sweep gaps (#366)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* FIX: ``open_nexradlevel2_datatree`` decodes volumes with interior sweep-index gaps end-to-end — translate sweep label → compact position in ``NexradLevel2Store.open_store_coordinates`` so the per-sweep entrypoint stops positionally indexing the compacted ``msg_31_header`` (follow-up to {pull}`362`) ({issue}`366`, {pull}`374`) by [@aladinor](https://github.com/aladinor)
 * DOC: Add projection comparison and cartopy map examples to ``Georeference_TargetCRS`` notebook by [@syedhamidali](https://github.com/syedhamidali)
 * DOC: Add full-form descriptions for all supported radar formats in README.md by [@syedhamidali](https://github.com/syedhamidali)
 * ADD: India Meteorological Department (IMD) radar NetCDF reader (``IMDBackendEntrypoint``, ``open_imd_datatree``). IMD stores one sweep per file; ``open_imd_datatree`` accepts a single file or a list of files to assemble a multi-sweep volume ({issue}`368`, {pull}`367`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/docs/notebooks/nexrad_read_chunks.md
+++ b/docs/notebooks/nexrad_read_chunks.md
@@ -73,11 +73,9 @@ chunk_paths = []
 try:
     fs = fsspec.filesystem("s3", anon=True)
     volumes = sorted(fs.ls("unidata-nexrad-level2-chunks/KABR/"))
-    # Real-time chunks arrive incrementally and age out one at a time, so the
-    # most recent volume may be mid-flight (no S yet) and recent ones may have
-    # lost their S. Walk newest -> oldest and require BOTH the S (start) and
-    # E (end) chunks so we know the volume is complete and decodable.
-    for vol in reversed(volumes):
+    # Newest volume may be mid-flight (no E); aging volumes may have lost
+    # their S. Walk back until we find one with both chunks present.
+    for vol in list(reversed(volumes))[:10]:
         candidate_paths = sorted(fs.ls(vol))
         suffixes = {p.rsplit("-", 1)[-1].rsplit("_", 1)[-1] for p in candidate_paths}
         if "S" in suffixes and "E" in suffixes:

--- a/docs/notebooks/nexrad_read_chunks.md
+++ b/docs/notebooks/nexrad_read_chunks.md
@@ -73,13 +73,16 @@ chunk_paths = []
 try:
     fs = fsspec.filesystem("s3", anon=True)
     volumes = sorted(fs.ls("unidata-nexrad-level2-chunks/KABR/"))
-    if volumes:
-        candidate_paths = sorted(fs.ls(volumes[-1]))
-        # The S (start) chunk carries the volume header (AR2V prefix); without
-        # it the concatenated bytes can't be decoded. Real-time chunks age out,
-        # so the most recent volume may have only I/E chunks left.
-        if any(p.endswith("_S") for p in candidate_paths):
+    # Real-time chunks arrive incrementally and age out one at a time, so the
+    # most recent volume may be mid-flight (no S yet) and recent ones may have
+    # lost their S. Walk newest -> oldest and require BOTH the S (start) and
+    # E (end) chunks so we know the volume is complete and decodable.
+    for vol in reversed(volumes):
+        candidate_paths = sorted(fs.ls(vol))
+        suffixes = {p.rsplit("-", 1)[-1].rsplit("_", 1)[-1] for p in candidate_paths}
+        if "S" in suffixes and "E" in suffixes:
             chunk_paths = candidate_paths
+            break
 except Exception:
     pass
 

--- a/docs/notebooks/nexrad_read_chunks.md
+++ b/docs/notebooks/nexrad_read_chunks.md
@@ -74,7 +74,12 @@ try:
     fs = fsspec.filesystem("s3", anon=True)
     volumes = sorted(fs.ls("unidata-nexrad-level2-chunks/KABR/"))
     if volumes:
-        chunk_paths = sorted(fs.ls(volumes[-1]))
+        candidate_paths = sorted(fs.ls(volumes[-1]))
+        # The S (start) chunk carries the volume header (AR2V prefix); without
+        # it the concatenated bytes can't be decoded. Real-time chunks age out,
+        # so the most recent volume may have only I/E chunks left.
+        if any(p.endswith("_S") for p in candidate_paths):
+            chunk_paths = candidate_paths
 except Exception:
     pass
 

--- a/docs/notebooks/nexrad_read_chunks.md
+++ b/docs/notebooks/nexrad_read_chunks.md
@@ -73,32 +73,40 @@ chunk_paths = []
 try:
     fs = fsspec.filesystem("s3", anon=True)
     volumes = sorted(fs.ls("unidata-nexrad-level2-chunks/KABR/"))
-    # Newest volume may be mid-flight (no E); aging volumes may have lost
-    # their S. Walk back until we find one with both chunks present.
-    for vol in list(reversed(volumes))[:10]:
-        candidate_paths = sorted(fs.ls(vol))
-        suffixes = {p.rsplit("-", 1)[-1].rsplit("_", 1)[-1] for p in candidate_paths}
-        if "S" in suffixes and "E" in suffixes:
-            chunk_paths = candidate_paths
-            break
+    if volumes:
+        chunk_paths = sorted(fs.ls(volumes[-1]))
 except Exception:
     pass
 
 if chunk_paths:
-    print(f"Using live S3 chunks: {len(chunk_paths)} files")
+    print(f"Found {len(chunk_paths)} live S3 chunks")
     for p in chunk_paths[:3]:
         print(f"  {p.split('/')[-1]}")
     print(f"  ... {chunk_paths[-1].split('/')[-1]}")
 else:
-    print("S3 bucket empty or unreachable, using open-radar-data fixture")
+    print("S3 bucket unreachable, using open-radar-data fixture")
 ```
 
 ## Download / load chunk bytes
 
+Real-time S3 chunks age out one at a time, so the most recent volume can
+be missing the start (S) chunk that carries the AR2V volume header.
+`open_nexradlevel2_datatree` raises `ValueError` in that case, so we let
+it validate the listing for us and fall back to the open-radar-data
+fixture when it rejects the bytes.
+
 ```{code-cell}
+all_bytes = None
+
 if chunk_paths:
-    all_bytes = [fs.open(p, "rb").read() for p in chunk_paths]
-else:
+    candidate = [fs.open(p, "rb").read() for p in chunk_paths]
+    try:
+        xd.io.open_nexradlevel2_datatree(candidate)
+        all_bytes = candidate
+    except ValueError as e:
+        print(f"S3 listing rejected: {e}")
+
+if all_bytes is None:
     import tarfile
     from pathlib import Path
 

--- a/tests/io/test_nexrad_level2.py
+++ b/tests/io/test_nexrad_level2.py
@@ -2291,6 +2291,83 @@ class TestListInputWithIncompleteSweep:
         )
 
 
+class TestInteriorGapCoordinates:
+    """Regression for openradar/xradar#366: open_store_coordinates must
+    translate sweep label -> compact index when iterating msg_31_header,
+    which is shorter than the declared cut count after an interior gap.
+    """
+
+    # KLOT 2021-11-04 17:42 shape: 12 declared cuts, label 10 dropped.
+    PRESENT_KEYS = (0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 11)
+
+    @staticmethod
+    def _make_store(present_keys, group_label, msg_5_has_elev_data=True):
+        from types import SimpleNamespace
+
+        from xradar.io.backends.nexrad_level2 import NexradLevel2Store
+
+        # Distinct per-position elevation so the test fails (not just on
+        # IndexError) if label->position translation regresses to wrong index.
+        msg_31_header = [
+            [
+                {
+                    "azimuth_angle": 0,
+                    "elevation_angle": pos,
+                    "collect_date": 1,
+                    "collect_ms": 0,
+                }
+            ]
+            for pos in range(len(present_keys))
+        ]
+        declared = max(present_keys) + 1
+        elev_data = [{"elevation_angle": 0.5 * i} for i in range(declared)]
+        sweep_ds = {
+            "sweep_constant_data": {
+                "VOL": {
+                    "lon": -97.0,
+                    "lat": 35.0,
+                    "height": 300.0,
+                    "feedhorn_height": 1.0,
+                }
+            },
+            "sweep_data": {
+                "REF": {"first_gate": 0.0, "gate_spacing": 250.0, "ngates": 4}
+            },
+        }
+        data = {k: sweep_ds for k in present_keys}
+        root = SimpleNamespace(
+            data=data,
+            msg_31_header=msg_31_header,
+            msg_31_data_header=[{"msg_type": 31} for _ in range(declared)],
+            msg_5={"elevation_data": elev_data} if msg_5_has_elev_data else {},
+        )
+
+        # Subclass to avoid mutating NexradLevel2Store class-level descriptors.
+        class _SyntheticStore(NexradLevel2Store):
+            root = property(lambda self: root)
+            ds = property(lambda self: data[self._group])
+
+        store = _SyntheticStore.__new__(_SyntheticStore)
+        store._group = group_label
+        store._filename = "<synthetic>"
+        return store
+
+    @pytest.mark.parametrize("group_label", PRESENT_KEYS)
+    @pytest.mark.parametrize("msg_5_has_elev_data", [True, False])
+    def test_each_kept_sweep_round_trips(self, group_label, msg_5_has_elev_data):
+        store = self._make_store(
+            self.PRESENT_KEYS,
+            group_label=group_label,
+            msg_5_has_elev_data=msg_5_has_elev_data,
+        )
+        coords = store.open_store_coordinates()
+        assert coords["sweep_number"].item() == group_label
+        # Per-position elevation in the synthetic header confirms the
+        # label->compact-index translation (not just absence of IndexError).
+        expected_position = sorted(self.PRESENT_KEYS).index(group_label)
+        assert coords["elevation"].values[0] == expected_position
+
+
 class TestRealChunkFiles:
     """Integration tests using real NEXRAD chunk files from open-radar-data."""
 

--- a/xradar/io/backends/nexrad_level2.py
+++ b/xradar/io/backends/nexrad_level2.py
@@ -1752,7 +1752,9 @@ class NexradLevel2Store(AbstractDataStore):
         return mname, Variable((dim, "range"), data, attrs, encoding)
 
     def open_store_coordinates(self):
-        msg_31_header = self.root.msg_31_header[self._group]
+        # msg_31_header is compacted past interior gaps; translate label -> position.
+        header_idx = sorted(self.root.data).index(self._group)
+        msg_31_header = self.root.msg_31_header[header_idx]
         msg_31_data_header = self.root.msg_31_data_header[self._group]
         # check message type
         msg_type = msg_31_data_header["msg_type"]
@@ -1805,7 +1807,7 @@ class NexradLevel2Store(AbstractDataStore):
                 "elevation_angle"
             ]
         else:
-            fixed_angle = self.root.msg_31_header[self._group][0]["elevation_angle"]
+            fixed_angle = self.root.msg_31_header[header_idx][0]["elevation_angle"]
         fixed_angle *= angle_scale
 
         coords = {


### PR DESCRIPTION
## Summary

Follow-up to #362. That PR fixed the top-level iteration in `open_nexradlevel2_datatree` but `NexradLevel2Store.open_store_coordinates` still positionally indexed `self.root.msg_31_header` by sweep label, so volumes with an interior sweep gap fell over with `IndexError` (instead of the original `KeyError`).

`msg_31_header` is compacted to `len(nex.data)`; `msg_31_data_header` keeps the declared length with a placeholder. The fix translates label → compact position via `sorted(self.root.data).index(self._group)` and applies it at both call sites in `open_store_coordinates`.

Closes #366.

## Repro (from the issue)

```python
import fsspec, xradar as xd
url = "s3://unidata-nexrad-level2/2021/11/04/KLOT/KLOT20211104_174202_V06"
with fsspec.open(url, mode="rb", anon=True) as fh:
    buf = fh.read()
xd.io.open_nexradlevel2_datatree(buf)
# Before: IndexError: list index out of range  at open_store_coordinates
# After:  DataTree with sweep_0..sweep_9, sweep_11
```

## Test plan

- [x] New `TestInteriorGapCoordinates` exercises `open_store_coordinates` directly (22 cases: 11 present labels × 2 `msg_5.elevation_data` states)
- [x] Per-position elevation values in the synthetic header verify the label→position translation, not just absence of `IndexError`
- [x] Confirmed all 22 cases fail on the unfixed code with the exact `IndexError` from the issue, and pass with the fix
- [x] Full `tests/io/test_nexrad_level2.py` runs clean (126 passed)
- [x] `black --check` and `ruff check` clean

## Notes

- The #362 tests mock `open_sweeps_as_dict`, which short-circuits before reaching the buggy path — that's how the bug shipped. The new tests drop one layer deeper to a synthetic `NexradLevel2Store`, so the actual call site is exercised.
- Real-NODD integration coverage (the three KLOT URLs from the issue) is intentionally left out of this PR; it can land later via an `open-radar-data` fixture (tracked separately).