### PR TITLE
FIX: IRIS reader rotates first-loaded moment by 1 ray (#357)

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* FIX: IRIS reader rotates the first-loaded moment in each sweep by 1 ray — ``IrisRawFile._get_ray_record_offsets_and_data`` initialised ``j = -1`` so the first matching ray of the first-loaded moment was written to ``raw_data[-1]``; affects files without ``DB_XHDR`` (data-type bit 0) where ``DB_DBT`` becomes the rotated moment ({issue}`357`, {pull}`375`) by [@aladinor](https://github.com/aladinor)
 * DOC: Add projection comparison and cartopy map examples to ``Georeference_TargetCRS`` notebook by [@syedhamidali](https://github.com/syedhamidali)
 * DOC: Add full-form descriptions for all supported radar formats in README.md by [@syedhamidali](https://github.com/syedhamidali)
 * ADD: India Meteorological Department (IMD) radar NetCDF reader (``IMDBackendEntrypoint``, ``open_imd_datatree``). IMD stores one sweep per file; ``open_imd_datatree`` accepts a single file or a list of files to assemble a multi-sweep volume ({issue}`368`, {pull}`367`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/docs/notebooks/nexrad_read_chunks.md
+++ b/docs/notebooks/nexrad_read_chunks.md
@@ -79,20 +79,34 @@ except Exception:
     pass
 
 if chunk_paths:
-    print(f"Using live S3 chunks: {len(chunk_paths)} files")
+    print(f"Found {len(chunk_paths)} live S3 chunks")
     for p in chunk_paths[:3]:
         print(f"  {p.split('/')[-1]}")
     print(f"  ... {chunk_paths[-1].split('/')[-1]}")
 else:
-    print("S3 bucket empty or unreachable, using open-radar-data fixture")
+    print("S3 bucket unreachable, using open-radar-data fixture")
 ```
 
 ## Download / load chunk bytes
 
+Real-time S3 chunks age out one at a time, so the most recent volume can
+be missing the start (S) chunk that carries the AR2V volume header.
+`open_nexradlevel2_datatree` raises `ValueError` in that case, so we let
+it validate the listing for us and fall back to the open-radar-data
+fixture when it rejects the bytes.
+
 ```{code-cell}
+all_bytes = None
+
 if chunk_paths:
-    all_bytes = [fs.open(p, "rb").read() for p in chunk_paths]
-else:
+    candidate = [fs.open(p, "rb").read() for p in chunk_paths]
+    try:
+        xd.io.open_nexradlevel2_datatree(candidate)
+        all_bytes = candidate
+    except ValueError as e:
+        print(f"S3 listing rejected: {e}")
+
+if all_bytes is None:
     import tarfile
     from pathlib import Path
 

--- a/tests/io/test_iris.py
+++ b/tests/io/test_iris.py
@@ -380,3 +380,41 @@ def test_open_iris_datatree_optional_groups(iris0_file):
     assert "radar_parameters" in dtree.children
     assert "georeferencing_correction" in dtree.children
     assert "radar_calibration" in dtree.children
+
+
+def test_first_loaded_moment_aligned_with_others(iris0_file):
+    """Regression for openradar/xradar#357.
+
+    The first moment loaded in a sweep takes the on-the-fly path in
+    ``IrisRawFile._get_ray_record_offsets_and_data``. An off-by-one in
+    that path (``j = -1``) caused its first matching ray to be written
+    to ``raw_data[-1]`` (the last row), rotating the whole moment by 1
+    ray. Subsequent moments use a separate cache-hit path and were fine.
+
+    ``iris0_file`` (cor-main) has DB_DBZ as ``data_types[0]`` and no
+    DB_XHDR, so DBZH is the first-loaded user-visible moment. Per-row
+    correlation between DBZH and other moments derived from the same
+    dwell must peak at k=0 (no offset).
+    """
+    dtree = open_iris_datatree(iris0_file)
+    sw = dtree["sweep_0"].to_dataset()
+
+    def best_shift(a, b):
+        m = ~(np.isnan(a) | np.isnan(b))
+        a = np.where(m, a, 0.0)
+        b = np.where(m, b, 0.0)
+        a = a - a.mean()
+        b = b - b.mean()
+        scores = [(((a * np.roll(b, k, axis=0)).sum()), k) for k in range(-3, 4)]
+        return max(scores)[1]
+
+    # Moments physically related to DBZH (reflectivity-like statistics).
+    # VRADH is excluded — velocity correlates poorly with reflectivity and
+    # the noise-driven peak is not informative for alignment.
+    related = [m for m in ("ZDR", "KDP", "PHIDP", "RHOHV") if m in sw.data_vars]
+    assert related, "test fixture must expose at least one DBZH-related moment"
+
+    for moment in related:
+        assert (
+            best_shift(sw["DBZH"].values, sw[moment].values) == 0
+        ), f"DBZH is row-rotated relative to {moment}"

--- a/xradar/io/backends/iris.py
+++ b/xradar/io/backends/iris.py
@@ -3461,7 +3461,7 @@ class IrisRawFile(IrisRecordFile, IrisIngestHeader):
 
         #  get all ray record numbers and offsets
         # also get data for
-        j = -1
+        j = 0
         for i in range(ray_count):
             if idx is not None:
                 if (i % data_type_count) == idx:


### PR DESCRIPTION
## Summary

Closes #357.

`IrisRawFile._get_ray_record_offsets_and_data` initialises its destination index `j = -1`, so the **first matching ray** of the **first-loaded moment** is written to `raw_data[-1]` (the last row of the buffer). Subsequent matches go to `raw_data[0]`, `raw_data[1]`, … rotating the entire moment by **one ray**. Other moments use a separate cache-hit code path with `enumerate(...)` starting at 0 and are unaffected.

```diff
-        j = -1
+        j = 0
         for i in range(ray_count):
             if idx is not None:
                 if (i % data_type_count) == idx:
                     recnum, recoff = self.get_ray(raw_data[j])
                     j += 1
```

## Why DBT specifically

The first moment in `data_types` is whatever the first set bit of `dsp_data_mask.mask_word_0` indexes into:

- Files **with** `DB_XHDR` (bit 0): XHDR is loaded first → XHDR is the rotated one. XHDR carries per-ray timing structs, not user-visible data, so the rotation is invisible.
- Files **without** `DB_XHDR` (bit 1 = `DB_DBT` is the first set bit, e.g. older IRIS / Spanish + Portuguese files in the issue): `DB_DBT` is loaded first → users see DBTH offset by 1 ray vs every other moment in the sweep.

## Reproduction & confirmation

Three NODD-style files from the issue reporter:

| File | DB_XHDR | xhdr_type | DBT shift before fix | DBT shift after fix |
|---|---|---|---|---|
| `PRT231225000005.RAWD2A3` | yes | 0 | 0 | 0 |
| `PRT251225000005.RAWV3S8` | no | 0xFFFFFFFF | -1 ray | 0 |
| `VAL241029150611.RAWWSVX...` | no | 0xFFFFFFFF | -1 ray | 0 |

Independent verification: forcing `get_moment(DB_DBZ)` before `DB_DBT` (reverse load order) flipped the shift sign on the broken files — the rotated moment is always whichever one is loaded first, regardless of its data-type code. With `j = 0` the rotation disappears for any load order.

## What's NOT the issue

The reporter's hypothesis ("printing `azi_start` in `get_moment` confirms DBT's azimuths are shifted") was misleading — the ray-header bytes the reader reads at the offsets stored in `sweep["ray_offsets"]` are **identical across moments at the same logical ray index**. The file does not carry per-moment azimuth offsets. The reporter's per-moment-azimuth-storage workaround treated the symptom; this fix removes the cause.

## Test plan

- [x] New `test_first_loaded_moment_aligned_with_others` uses the existing `iris0_file` fixture (cor-main, `DB_DBZ` as `data_types[0]` so the bug is exposed). Computes per-row cross-correlation between `DBZH` and `ZDR`/`KDP`/`PHIDP`/`RHOHV` at offsets k ∈ [-3, 3] and asserts the peak is at k=0.
- [x] Test passes with the fix; fails with `j = -1` (peak at k=-1 for all four moments).
- [x] Existing IRIS suite (26 → 27 passed) clean: `pytest tests/io/test_iris.py`
- [x] `black --check` and `ruff check` clean

## Notes

- Likely been in xradar (and inherited from wradlib) since the IRIS reader was first written.
- Files with `DB_XHDR` masked the bug because XHDR isn't user-visible — only files without it expose the rotation as a visible DBT offset.