### PR TITLE
FIX : enable the function “to_cfradial2” to choose a default storage engine

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* FIX: ensure `to_cfradial2` correctly selects the default storage engine when none is provided, ({pull}`378`) by [@chfer](https://github.com/chfer)
 * DOC: Add projection comparison and cartopy map examples to ``Georeference_TargetCRS`` notebook by [@syedhamidali](https://github.com/syedhamidali)
 * DOC: Add full-form descriptions for all supported radar formats in README.md by [@syedhamidali](https://github.com/syedhamidali)
 * ADD: India Meteorological Department (IMD) radar NetCDF reader (``IMDBackendEntrypoint``, ``open_imd_datatree``). IMD stores one sweep per file; ``open_imd_datatree`` accepts a single file or a list of files to assemble a multi-sweep volume ({issue}`368`, {pull}`367`) by [@syedhamidali](https://github.com/syedhamidali)

--- a/tests/io/test_cfradial2.py
+++ b/tests/io/test_cfradial2.py
@@ -8,6 +8,7 @@ import xarray as xr
 
 import xradar as xd
 from xradar.io.backends import cfradial2 as cf2
+from xradar.io.export import cfradial2 as export_cf2
 
 
 def _write_institutional_cfradial2(outfile):
@@ -136,6 +137,37 @@ def test_open_cfradial2_normalizes_common_aliases(temp_file):
 def test_open_cfradial2_invalid_path():
     with pytest.raises(FileNotFoundError):
         xd.io.open_cfradial2_datatree("missing-cfradial2-file.nc")
+
+
+@pytest.mark.parametrize(
+    ("available", "expected_engine"),
+    [
+        ("netCDF4", "netcdf4"),
+        ("h5netcdf", "h5netcdf"),
+    ],
+)
+def test_to_cfradial2_selects_default_engine(
+    monkeypatch, tmp_path, available, expected_engine
+):
+    # build a tiny DataTree with the minimum structure needed for export, and a root history attribute since export appends to it
+    dtree = xr.DataTree.from_dict({"/": xr.Dataset(attrs={"history": ""})})
+
+    # monkeypatch has_import to simulate different available engines, and ensure that the expected one is selected when engine=None
+    monkeypatch.setattr(export_cf2, "has_import", lambda name: name == available)
+
+    # monkeypatch DataTree.to_netcdf to avoid writing a real file and let the test intercept the `engine` argument
+    seen = {}
+
+    def _capture_to_netcdf(self, filename, engine=None, **kwargs):
+        seen["engine"] = engine
+
+    monkeypatch.setattr(xr.DataTree, "to_netcdf", _capture_to_netcdf, raising=True)
+
+    # call to_cfradial2 with engine=None, which should trigger the default engine selection logic
+    export_cf2.to_cfradial2(dtree, tmp_path / "out.nc", engine=None)
+
+    # does the intercepted call to to_netcdf have the expected engine ?
+    assert seen["engine"] == expected_engine
 
 
 @pytest.mark.parametrize(

--- a/xradar/io/export/cfradial2.py
+++ b/xradar/io/export/cfradial2.py
@@ -58,9 +58,9 @@ def to_cfradial2(dtree, filename, engine=None, timestep=None):
     """
     if engine is None:
         if has_import("netCDF4"):
-            engine == "netcdf4"
+            engine = "netcdf4"
         elif has_import("h5netcdf"):
-            engine == "h5netcdf"
+            engine = "h5netcdf"
         else:
             raise ImportError(
                 "xradar: ``netCDF4`` or ``h5netcdf`` needed to perform this operation."


### PR DESCRIPTION
This PR aims to correct two small typo bugs in the function “to_cfradial2” located in the module “xradar/io/export/cfradial2.py” at lines 61 and 63. 
- In the first commit of this PR branch (fix/cfradial2-default-engine-test  -  8b7efd975) a pytest , “tests/io/test_cfradial2.py::test_to_cfradial2_selects_default_engine”,is added which demonstrates that the typos prevent the “to_cfradial2” function from choosing a default storage engine to write the DataTree through “xarray.DataTree.to_netcdf”. The value of the engine there remains “None”, so the test fails.
- In the second commit (830f81d38) the two typos are corrected and the test succeeds.
