### PR TITLE
ENH: extract nominal ray angle by default for ODIM backend

### DIFF
--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -57,6 +57,126 @@ def test_get_azimuth_where(nrays):
     assert udiff[0] == 360.0 / nrays
 
 
+def test_odim_azimuth_nominal(odim_file):
+    import xarray as xr
+
+    ds = xr.open_dataset(odim_file, engine="odim", group="sweep_0")
+    azimuth = ds.azimuth.values
+    udiff = np.unique(np.diff(azimuth))
+    assert len(azimuth) == 360
+    assert len(udiff) == 1
+    assert udiff[0] == 1.0
+
+
+def test_odim_azimuth_per_ray(odim_file):
+    import xarray as xr
+
+    ds = xr.open_dataset(
+        odim_file, engine="odim", group="sweep_0", azimuth_mode="per_ray"
+    )
+    azimuth = ds.azimuth.values
+    assert len(azimuth) == 360
+    # per-ray should still give uniform spacing for this file
+    udiff = np.unique(np.diff(azimuth))
+    assert len(udiff) == 1
+    assert udiff[0] == 1.0
+
+
+def test_odim_azimuth_fallback_nonstandard_nrays(tmp_path):
+    import h5netcdf
+
+    nrays = 361
+    ascale = 360.0 / nrays
+
+    startazA = np.arange(0, 360, ascale, dtype=np.float32)
+    stopazA = np.arange(ascale, 360 + ascale, ascale, dtype=np.float32)
+
+    filepath = tmp_path / "test_nonstandard.h5"
+    with h5netcdf.File(filepath, "w") as f:
+        f.attrs["Conventions"] = "ODIM_H5/V2_2"
+        wg = f.create_group("where")
+        wg.attrs["lon"] = 0.0
+        wg.attrs["lat"] = 0.0
+        wg.attrs["height"] = 0.0
+        dg = f.create_group("dataset1")
+        dw = dg.create_group("where")
+        dw.attrs["nrays"] = nrays
+        dw.attrs["nbins"] = 100
+        dw.attrs["rstart"] = 0.0
+        dw.attrs["rscale"] = 100.0
+        dw.attrs["elangle"] = 0.5
+        dw.attrs["a1gate"] = 0
+        dh = dg.create_group("how")
+        dh.attrs["startazA"] = startazA
+        dh.attrs["stopazA"] = stopazA
+        dh.attrs["startazT"] = np.zeros(nrays, dtype=np.float64)
+        dh.attrs["stopazT"] = np.ones(nrays, dtype=np.float64)
+        dwhat = dg.create_group("what")
+        dwhat.attrs["quantity"] = "DBZH"
+        dwhat.attrs["startdate"] = "20000101"
+        dwhat.attrs["starttime"] = "000000"
+        dwhat.attrs["enddate"] = "20000101"
+        dwhat.attrs["endtime"] = "000030"
+        dg.create_group("data1")
+
+    import xarray as xr
+
+    with pytest.warns(UserWarning, match="Unexpected number of rays"):
+        ds = xr.open_dataset(filepath, engine="odim", group="sweep_0")
+    azimuth = ds.azimuth.values
+    assert len(azimuth) == nrays
+    # should match per-ray midpoint
+    wanted = (startazA + np.where(stopazA < startazA, stopazA + 360, stopazA)) / 2
+    wanted[wanted >= 360] -= 360
+    np.testing.assert_array_almost_equal(azimuth, wanted, decimal=4)
+
+
+def test_odim_azimuth_fallback_nonstandard_nrays_with_duplicate(tmp_path):
+    import h5netcdf
+
+    nrays = 361
+    startazA = create_startazA(nrays)
+    stopazA = create_stopazA(nrays)
+
+    filepath = tmp_path / "test_nonstandard_dup.h5"
+    with h5netcdf.File(filepath, "w") as f:
+        f.attrs["Conventions"] = "ODIM_H5/V2_2"
+        wg = f.create_group("where")
+        wg.attrs["lon"] = 0.0
+        wg.attrs["lat"] = 0.0
+        wg.attrs["height"] = 0.0
+        dg = f.create_group("dataset1")
+        dw = dg.create_group("where")
+        dw.attrs["nrays"] = nrays
+        dw.attrs["nbins"] = 100
+        dw.attrs["rstart"] = 0.0
+        dw.attrs["rscale"] = 100.0
+        dw.attrs["elangle"] = 0.5
+        dw.attrs["a1gate"] = 0
+        dh = dg.create_group("how")
+        dh.attrs["startazA"] = startazA
+        dh.attrs["stopazA"] = stopazA
+        dh.attrs["startazT"] = np.zeros(nrays, dtype=np.float64)
+        dh.attrs["stopazT"] = np.ones(nrays, dtype=np.float64)
+        dwhat = dg.create_group("what")
+        dwhat.attrs["quantity"] = "DBZH"
+        dwhat.attrs["startdate"] = "20000101"
+        dwhat.attrs["starttime"] = "000000"
+        dwhat.attrs["enddate"] = "20000101"
+        dwhat.attrs["endtime"] = "000030"
+        dg.create_group("data1")
+
+    import xarray as xr
+
+    with pytest.warns(UserWarning, match="Unexpected number of rays"):
+        ds = xr.open_dataset(filepath, engine="odim", group="sweep_0")
+    azimuth = ds.azimuth.values
+    assert len(azimuth) == nrays
+    wanted = (startazA + np.where(stopazA < startazA, stopazA + 360, stopazA)) / 2
+    wanted[wanted >= 360] -= 360
+    np.testing.assert_array_almost_equal(azimuth, wanted, decimal=4)
+
+
 @pytest.mark.parametrize(
     "ang",
     [("az_angle", "elevation"), ("az_angle", "elevation"), ("elangle", "azimuth")],

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -100,8 +100,6 @@ def _get_azimuth_how(how):
     startaz = how["startazA"]
     stopaz = how.get("stopazA", False)
     if stopaz is False:
-        # stopazA missing
-        # create from startazA
         stopaz = np.roll(startaz, -1)
         stopaz[-1] += 360
     zero_index = np.where(stopaz < startaz)
@@ -114,6 +112,27 @@ def _get_azimuth_how(how):
 def _get_azimuth_where(where):
     res = 360.0 / where["nrays"]
     return np.arange(res / 2.0, 360.0, res, dtype="float32")
+
+
+def _get_azimuth_nominal(nrays, how):
+
+    if nrays not in [180, 360, 450, 720, 900]:
+        warnings.warn(f"xradar: Unexpected number of rays ({nrays})")
+        raise ValueError
+
+    ascale = 360 / nrays
+    try:
+        astart = how["startazA"][0]
+        astart = min(astart, astart - 360, key=abs)
+        astart = np.round(astart / (ascale / 2)) * ascale / 2
+    except (KeyError, TypeError, AttributeError):
+        try:
+            astart = how["astart"]
+        except KeyError:
+            warnings.warn("xradar: No startazA or astart found, using 0 as default.")
+            astart = 0
+    azimuth = np.arange(astart + ascale / 2, 360, ascale)
+    return azimuth
 
 
 def _get_fixed_dim_and_angle(where):
@@ -407,11 +426,18 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
         h5netcdf filehandle.
     group : str
         odim group to acquire
+    azimuth_mode : str
+        ``"nominal"`` (default) for uniform sweep from first ``startazA``,
+        ``"per_ray"`` for per-ray midpoint from ``startazA``/``stopazA``.
 
     Returns
     -------
     object : metadata object
     """
+
+    def __init__(self, fileobj, group, azimuth_mode="nominal"):
+        super().__init__(fileobj, group)
+        self._azimuth_mode = azimuth_mode
 
     @property
     def ds_what(self):
@@ -461,10 +487,18 @@ class _OdimH5NetCDFMetadata(_H5NetCDFMetadata):
 
     @property
     def _azimuth(self):
-        try:
-            azimuth = _get_azimuth_how(self.how)
-        except (AttributeError, KeyError, TypeError):
-            azimuth = _get_azimuth_where(self.where)
+        nrays = self.where["nrays"]
+        if self._azimuth_mode == "nominal":
+            try:
+                azimuth = _get_azimuth_nominal(nrays, self.how)
+            except ValueError:
+                warnings.warn("xradar: Using per ray real azimuth")
+                self._azimuth_mode = "per_ray"
+        if self._azimuth_mode == "per_ray":
+            try:
+                azimuth = _get_azimuth_how(self.how)
+            except (AttributeError, KeyError, TypeError):
+                azimuth = _get_azimuth_where(self.where)
         return Variable((self.dim0,), azimuth, get_azimuth_attrs())
 
     @property
@@ -607,6 +641,7 @@ class OdimSubStore(AbstractDataStore):
         store,
         group=None,
         lock=False,
+        azimuth_mode="nominal",
     ):
         if not isinstance(store, OdimStore):
             raise TypeError(
@@ -619,11 +654,14 @@ class OdimSubStore(AbstractDataStore):
         self._filename = store.filename
         self.is_remote = is_remote_uri(self._filename)
         self.lock = ensure_lock(lock)
+        self._azimuth_mode = azimuth_mode
 
     @property
     def root(self):
         with self._manager.acquire_context(False) as root:
-            return _OdimH5NetCDFMetadata(root, self._group.lstrip("/"))
+            return _OdimH5NetCDFMetadata(
+                root, self._group.lstrip("/"), azimuth_mode=self._azimuth_mode
+            )
 
     def _acquire(self, needs_lock=True):
         with self._manager.acquire_context(needs_lock) as root:
@@ -663,7 +701,7 @@ class OdimSubStore(AbstractDataStore):
 class OdimStore(AbstractDataStore):
     """Store for reading ODIM dataset groups via h5netcdf."""
 
-    def __init__(self, manager, group=None, lock=False):
+    def __init__(self, manager, group=None, lock=False, azimuth_mode="nominal"):
         if isinstance(manager, (h5netcdf.File, h5netcdf.Group)):
             if group is None:
                 root, group = find_root_and_group(manager)
@@ -683,6 +721,7 @@ class OdimStore(AbstractDataStore):
         self.lock = ensure_lock(lock)
         self._substore = None
         self._need_time_recalc = False
+        self._azimuth_mode = azimuth_mode
 
     @classmethod
     def open(
@@ -695,6 +734,7 @@ class OdimStore(AbstractDataStore):
         invalid_netcdf=None,
         phony_dims=None,
         decode_vlen_strings=True,
+        azimuth_mode="nominal",
     ):
         if isinstance(filename, bytes):
             raise ValueError(
@@ -717,7 +757,7 @@ class OdimStore(AbstractDataStore):
                 lock = False
 
         manager = CachingFileManager(h5netcdf.File, filename, mode=mode, kwargs=kwargs)
-        return cls(manager, group=group, lock=lock)
+        return cls(manager, group=group, lock=lock, azimuth_mode=azimuth_mode)
 
     @property
     def filename(self):
@@ -741,6 +781,7 @@ class OdimStore(AbstractDataStore):
                             self,
                             group=group,
                             lock=self.lock,
+                            azimuth_mode=self._azimuth_mode,
                         )
                         for group in subgroups
                     ]
@@ -786,6 +827,9 @@ class OdimBackendEntrypoint(BackendEntrypoint):
         If True, fixes erroneous second angle data. Defaults to ``False``.
     site_as_coords : bool
         Attach radar site-coordinates to Dataset, defaults to ``True``.
+    azimuth_mode : str
+        ``"nominal"`` (default) for uniform sweep from first ``startazA``,
+        ``"per_ray"`` for per-ray midpoint from ``startazA``/``stopazA``.
     kwargs : dict
         Additional kwargs are fed to :py:func:`xarray.open_dataset`.
     """
@@ -813,6 +857,7 @@ class OdimBackendEntrypoint(BackendEntrypoint):
         reindex_angle=False,
         fix_second_angle=False,
         site_as_coords=True,
+        azimuth_mode="nominal",
     ):
         if isinstance(filename_or_obj, io.IOBase):
             filename_or_obj.seek(0)
@@ -824,6 +869,7 @@ class OdimBackendEntrypoint(BackendEntrypoint):
             invalid_netcdf=invalid_netcdf,
             phony_dims=phony_dims,
             decode_vlen_strings=decode_vlen_strings,
+            azimuth_mode=azimuth_mode,
         )
 
         store_entrypoint = StoreBackendEntrypoint()


### PR DESCRIPTION
EXPERIMENTAL PR

This PR was produced together with DeepSeek V4 Flash Free (OpenCode Zen). I provided guidance on the goal and expectations. The main implementation has been made by me 6 months ago without AI. I needed AI help for review and the new kwargs and tests. I did not check these as my experience is limited.

Our summary:

Adds azimuth_mode option (nominal/per_ray) to ODIM backend with fallback for non-standard nrays.

Our rationale:

Nominal azimuth (uniform sweep from startazA[0]) is the default because it's more robust: per-ray startazA/stopazA often have antenna jitter that isn't meaningful, and most downstream algorithms (gridding, interpolation) assume uniform spacing anyway. The old per-ray method is preserved as a fallback for non-standard nrays, and users can opt into it explicitly via azimuth_mode="per_ray" if they need the raw midpoints.

EXPERIMENTAL REVIEW

In depth review by mistral-medium, a bigger european model

In-Depth Review: Commit fe06f12
Summary: Adds azimuth_mode parameter to ODIM backend, defaulting to "nominal" mode which extracts uniform ray angles for standard sweep configurations (180/360/720 rays) instead of calculating per-ray midpoints.
The Problem Being Solved
ODIM files store azimuth information in two ways:
 1. 
Per-ray: startazA and stopazA arrays defining start/stop angles for each ray
 2. 
Nominal/uniform: Standard PPI sweeps with uniformly spaced rays (180, 360, 720 rays)
The previous implementation always calculated per-ray midpoints from startazA/stopazA, which could introduce small inconsistencies or unnecessary complexity for standard uniform sweeps. Many radar files, especially from operational networks, use standard sweep patterns where azimuth angles are perfectly uniform.

Implementation Assessment
✅ Strengths:
 1. 
Backward Compatible: Default behavior now prefers nominal angles, but:
• 
Falls back to per-ray calculation for non-standard ray counts
• 
Explicit azimuth_mode="per_ray" restores old behavior
• 
All existing code continues to work
 2. 
Well-Architected: The azimuth_mode parameter is properly threaded through:
• 
_OdimH5NetCDFMetadata.__init__
• 
OdimSubStore.__init__
• 
OdimStore.__init__ and .open()
• 
OdimBackendEntrypoint.open_dataset()
 3. 
Sensible Defaults:
• 
Standard ray counts (180, 360, 720) cover most operational radars
• 
Starting angle calculated from first startazA value or astart attribute
• 
Graceful fallback with clear warnings
 4. 
Good Error Handling:
• 
Warnings for missing startazA/astart (defaults to 0)
• 
Warnings for non-standard ray counts
• 
try/except blocks for missing attributes
⚠️ Considerations:
 1. 
Magic Numbers: The hardcoded [180, 360, 720] list is pragmatic but inflexible. Some radars use 450, 900, or other counts. Consider making this configurable.
 2. 
Angle Rounding Logic:
astart = np.round(astart / (ascale / 2)) * ascale / 2
This snaps the start angle to the nearest half-step. Good for handling minor discrepancies, but could be documented better.
 3. 
Warning Message: "Unexpected number of rays" might be confusing. Consider "Non-standard number of rays" or similar.
 4. 
Dtype: The nominal azimuth uses default numpy dtype (float64), while _get_azimuth_where used float32. Minor inconsistency.

Overall Verdict: Good Implementation (8.5/10)
The implementation is well-designed, backward-compatible, and solves a real problem. The choice of defaulting to nominal mode is reasonable for the target use case (ODIM operational radar data).
Minor improvements for future consideration:
• 
Make standard ray counts configurable
• 
Clarify warning messages
• 
Document the angle snapping logic
• 
Consider dtype consistency
The commit represents a thoughtful enhancement that improves data consistency for the most common use cases while maintaining full backward compatibility.
