### PR TITLE
ENH: When importing ODIM files, extract the global attributes ‘wmo__i…

### DIFF
--- a/docs/history.md
+++ b/docs/history.md
@@ -2,6 +2,7 @@
 
 ## Development
 
+* ENH: When importing ODIM files, extract the global attributes "wmo__id", "node", "wmo__originating_centre" and "wmo__wsi" from the ODIM /what/source attribute
 * FIX: ``open_nexradlevel2_datatree`` decodes volumes with interior sweep-index gaps end-to-end — translate sweep label → compact position in ``NexradLevel2Store.open_store_coordinates`` so the per-sweep entrypoint stops positionally indexing the compacted ``msg_31_header`` (follow-up to {pull}`362`) ({issue}`366`, {pull}`374`) by [@aladinor](https://github.com/aladinor)
 * FIX: ensure `to_cfradial2` correctly selects the default storage engine when none is provided, ({pull}`378`) by [@chfer](https://github.com/chfer)
 * MNT: Add ``cfradial1_sgp_file`` session fixture and refactor 8 tests in ``test_util.py``/``test_accessors.py`` to share it instead of inlining ``DATASETS.fetch("sample_sgp_data.nc")``. Fixture returns the filename so each test opens its own DataTree, avoiding cross-test mutation ({issue}`346`, {pull}`347`) by [@aladinor](https://github.com/aladinor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,6 +39,21 @@ def odim_file2():
 
 
 @pytest.fixture(scope="session")
+def odim_file3():
+    return DATASETS.fetch("T_PAZA63_C_LFPW_20230420065041.h5")
+
+
+@pytest.fixture(scope="session")
+def odim_file4():
+    return DATASETS.fetch("202506090955_fianj_PVOL.h5")
+
+
+@pytest.fixture(scope="session")
+def odim_file5():
+    return DATASETS.fetch("SUR.202506091000.VOL.h5")
+
+
+@pytest.fixture(scope="session")
 def datamet_file():
     return DATASETS.fetch("H-000-VOL-ILMONTE-201907100700.tar.gz")
 

--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -9,6 +9,7 @@ ported from wradlib
 
 from contextlib import nullcontext
 
+import h5netcdf
 import numpy as np
 import pytest
 from xarray import DataTree, open_dataset, open_mfdataset
@@ -152,6 +153,77 @@ def test_get_a1gate():
     assert odim._get_a1gate(where) == 20
 
 
+@pytest.mark.parametrize(
+    ("source", "expected"),
+    [
+        (None, {}),
+        ("", {}),
+        ("WMO:26232", {"WMO": "26232"}),
+        (
+            " WIGOS:0-233-2-26232 , WMO:26232 , NOD:eesur ",
+            {"WIGOS": "0-233-2-26232", "WMO": "26232", "NOD": "eesur"},
+        ),
+        (
+            "wmo:26232,plc:Surgavere",
+            {"WMO": "26232", "PLC": "Surgavere"},
+        ),
+        (
+            b"WIGOS:0-233-2-26232,WMO:26232,NOD:eesur",
+            {"WIGOS": "0-233-2-26232", "WMO": "26232", "NOD": "eesur"},
+        ),
+        (
+            "RAD:EE41:SUBSYSTEM",
+            {"RAD": "EE41:SUBSYSTEM"},
+        ),
+        (
+            "WMO:26232,invalid,missing_colon,PLC:Surgavere",
+            {"WMO": "26232", "PLC": "Surgavere"},
+        ),
+        (
+            "WMO:26232,PLC:,NOD:eesur, :ignored",
+            {"WMO": "26232", "NOD": "eesur"},
+        ),
+        (
+            "WMO:11111,WMO:26232",
+            {"WMO": "26232"},
+        ),
+        (
+            "WIGOS:0-233-2-26232,WMO:26232,RAD:EE41,PLC:S\udcc3\udcbcrgavere,NOD:eesur",
+            {
+                "WIGOS": "0-233-2-26232",
+                "WMO": "26232",
+                "RAD": "EE41",
+                "PLC": "Sürgavere",
+                "NOD": "eesur",
+            },
+        ),
+    ],
+)
+def test_parse_odim_source_extensive(source, expected):
+    assert odim._parse_odim_source(source) == expected
+
+
+def test_parse_odim_source_handles_non_string_input():
+    class DummySource:
+        def __str__(self):
+            return "WMO:26232,NOD:eesur"
+
+    parsed = odim._parse_odim_source(DummySource())
+    assert parsed == {"WMO": "26232", "NOD": "eesur"}
+
+
+def test_parse_odim_source_surrogate_repair_unicodeerror_fallback():
+    # U+DC80 maps to raw byte 0x80 with surrogateescape, which is invalid
+    # as standalone UTF-8 and forces the repair decode to raise UnicodeError.
+    source = "PLC:\udc80_station,WMO:26232"
+
+    parsed = odim._parse_odim_source(source)
+
+    # Parser should not crash and should keep original value when repair fails.
+    assert parsed["PLC"] == "\udc80_station"
+    assert parsed["WMO"] == "26232"
+
+
 def test_OdimH5NetCDFMetadata(odim_file):
     store = odim.OdimStore.open(odim_file, group="sweep_0")
     with pytest.warns(DeprecationWarning):
@@ -175,6 +247,33 @@ def test_odim_dataset_has_close(odim_file):
     ds = open_dataset(odim_file, engine="odim", group="sweep_0")
     assert callable(getattr(ds, "_close", None))
     ds.close()
+
+
+@pytest.mark.parametrize(
+    "fixture_name",
+    ["odim_file", "odim_file2", "odim_file3", "odim_file4", "odim_file5"],
+)
+def test_odim_source_global_attributes(request, fixture_name):
+    filename = request.getfixturevalue(fixture_name)
+    print(f"Testing file: {filename}")
+
+    # Build expected global attrs from raw /what/source.
+    expected = {}
+    with h5netcdf.File(filename, mode="r") as root:
+        if "what" in root:
+            source = root["what"].attrs.get("source", None)
+            print(f"Raw ODIM source attribute: {source}")
+            parsed = odim._parse_odim_source(source)
+            for odim_key, global_attr in odim._ODIM_SOURCE_TO_GLOBAL_ATTRS.items():
+                value = parsed.get(odim_key)
+                if value:
+                    expected[global_attr] = value
+            print(f"Parsed ODIM source attributes: {expected}")
+
+    with open_dataset(filename, engine="odim", group="sweep_0") as ds:
+        print(f"Dataset global attributes: {ds.attrs}")
+        for global_attr, value in expected.items():
+            assert ds.attrs.get(global_attr) == value
 
 
 def test_open_odim_datatree(odim_file):
@@ -222,7 +321,7 @@ def test_open_odim_datatree(odim_file):
     assert "latitude" not in dtree.ds.data_vars
 
     # Validate attributes
-    assert len(dtree.attrs) == 9
+    assert len(dtree.attrs) == 10
     assert (
         dtree.attrs["Conventions"] == "ODIM_H5/V2_2"
     ), "Instrument name should match expected value"

--- a/tests/io/test_odim.py
+++ b/tests/io/test_odim.py
@@ -15,6 +15,7 @@ import pytest
 from xarray import DataTree, open_dataset, open_mfdataset
 
 from xradar.io.backends import odim, open_odim_datatree
+from xradar.io.backends.common import _maybe_recover_surrogate
 
 
 def create_startazA(nrays=360):
@@ -224,6 +225,19 @@ def test_parse_odim_source_surrogate_repair_unicodeerror_fallback():
     assert parsed["WMO"] == "26232"
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("Surgavere", "Surgavere"),
+        ("S\udcc3\udcbcrgavere", "Sürgavere"),
+        ("\udc80_station", "\udc80_station"),
+        (123, 123),
+    ],
+)
+def test_maybe_recover_surrogate(value, expected):
+    assert _maybe_recover_surrogate(value) == expected
+
+
 def test_OdimH5NetCDFMetadata(odim_file):
     store = odim.OdimStore.open(odim_file, group="sweep_0")
     with pytest.warns(DeprecationWarning):
@@ -266,7 +280,7 @@ def test_odim_source_global_attributes(request, fixture_name):
             parsed = odim._parse_odim_source(source)
             for odim_key, global_attr in odim._ODIM_SOURCE_TO_GLOBAL_ATTRS.items():
                 value = parsed.get(odim_key)
-                if value:
+                if value is not None:
                     expected[global_attr] = value
             print(f"Parsed ODIM source attributes: {expected}")
 

--- a/xradar/io/backends/common.py
+++ b/xradar/io/backends/common.py
@@ -40,6 +40,20 @@ def _maybe_decode(attr):
         return attr
 
 
+def _maybe_recover_surrogate(txt):
+    """Recover text that was decoded with surrogate escapes."""
+    if not isinstance(txt, str):
+        return txt
+
+    if any("\udc80" <= ch <= "\udcff" for ch in txt):
+        try:
+            return txt.encode("utf-8", "surrogateescape").decode("utf-8")
+        except UnicodeError:
+            pass
+
+    return txt
+
+
 def _calculate_angle_res(dim):
     # need to sort dim first
     angle_diff = np.diff(sorted(dim))

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -210,6 +210,50 @@ def _get_a1gate(where):
     return where["a1gate"]
 
 
+_ODIM_SOURCE_TO_GLOBAL_ATTRS = {
+    "WMO": "wmo__id",
+    "PLC": "site_name",
+    "NOD": "node",  # specific to OPERA
+    "ORG": "wmo__originating_centre",
+    "WIGOS": "wmo__wsi",
+}
+
+
+def _parse_odim_source(source):
+    """Parse ODIM /what/source string like 'K1:V1,K2:V2' into a dict."""
+    if source is None:
+        return {}
+
+    # ensure source is a string, decode if bytes
+    source = _maybe_decode(source)
+    if not isinstance(source, str):
+        source = str(source)
+
+    # Some ODIM source strings contain non asccii characters (e.g; 'ü'), which are encoded as UTF-8 bytes and
+    # then decoded with surrogateescape error handler, resulting in surrogate escape characters in the string.
+    # We need to detect this and recover the original UTF-8 string if possible.
+    # e.g. "Sürgavere" is read as an ASCII string instead of UTF-8 and the invalid bytes (ü = \xc3\xbc) are encoded with
+    # surrogate escape, resulting in "S\udcc3\udcbcrgavere"
+    if any("\udc80" <= ch <= "\udcff" for ch in source):
+        try:
+            source = source.encode("utf-8", "surrogateescape").decode("utf-8")
+        except UnicodeError:
+            pass
+
+    # parse key-value pairs separated by commas, and then keys and values separated by colons
+    parsed = {}
+    for item in source.split(","):
+        item = item.strip()
+        if not item or ":" not in item:
+            continue
+        key, value = item.split(":", 1)
+        key = key.strip().upper()
+        value = value.strip()
+        if key and value:
+            parsed[key] = value
+    return parsed
+
+
 class _H5NetCDFMetadata:
     """Wrapper around OdimH5/Gamic data fileobj for easy access of metadata.
 
@@ -766,7 +810,20 @@ class OdimStore(AbstractDataStore):
         )
 
     def get_attrs(self):
-        attributes = {"Conventions": "ODIM_H5/V2_2"}
+        attributes = {"Conventions": "ODIM_H5/V2_2", "source": "radar"}
+
+        with self._manager.acquire_context(False) as root:
+            # try to extract additional global attributes from /what/source string, if available
+            # see _ODIM_SOURCE_TO_GLOBAL_ATTRS for mapping of ODIM keys to global attribute names
+            if "what" in root:
+                source = _maybe_decode(root["what"].attrs.get("source", None))
+                if source:
+                    parsed = _parse_odim_source(source)
+                    for odim_key, global_attr in _ODIM_SOURCE_TO_GLOBAL_ATTRS.items():
+                        value = parsed.get(odim_key)
+                        if value:
+                            attributes[global_attr] = value
+
         return FrozenDict(attributes)
 
 

--- a/xradar/io/backends/odim.py
+++ b/xradar/io/backends/odim.py
@@ -78,6 +78,7 @@ from .common import (
     _get_required_root_dataset,
     _get_subgroup,
     _maybe_decode,
+    _maybe_recover_surrogate,
     _prepare_backend_ds,
 )
 
@@ -229,16 +230,12 @@ def _parse_odim_source(source):
     if not isinstance(source, str):
         source = str(source)
 
-    # Some ODIM source strings contain non asccii characters (e.g; 'ü'), which are encoded as UTF-8 bytes and
-    # then decoded with surrogateescape error handler, resulting in surrogate escape characters in the string.
-    # We need to detect this and recover the original UTF-8 string if possible.
+    # ODIM-H5 stores scalar attributes as 8-bit ASCII in the file. When the
+    # original text contains UTF-8 bytes, h5netcdf decodes them with surrogate
+    # escapes, so recover the original string here when possible.
     # e.g. "Sürgavere" is read as an ASCII string instead of UTF-8 and the invalid bytes (ü = \xc3\xbc) are encoded with
-    # surrogate escape, resulting in "S\udcc3\udcbcrgavere"
-    if any("\udc80" <= ch <= "\udcff" for ch in source):
-        try:
-            source = source.encode("utf-8", "surrogateescape").decode("utf-8")
-        except UnicodeError:
-            pass
+    # surrogate escape, resulting in "S\udcc3\udcbcrgavere". This has to be recovered back to the original string.
+    source = _maybe_recover_surrogate(source)
 
     # parse key-value pairs separated by commas, and then keys and values separated by colons
     parsed = {}
@@ -816,13 +813,11 @@ class OdimStore(AbstractDataStore):
             # try to extract additional global attributes from /what/source string, if available
             # see _ODIM_SOURCE_TO_GLOBAL_ATTRS for mapping of ODIM keys to global attribute names
             if "what" in root:
-                source = _maybe_decode(root["what"].attrs.get("source", None))
-                if source:
-                    parsed = _parse_odim_source(source)
-                    for odim_key, global_attr in _ODIM_SOURCE_TO_GLOBAL_ATTRS.items():
-                        value = parsed.get(odim_key)
-                        if value:
-                            attributes[global_attr] = value
+                parsed = _parse_odim_source(root["what"].attrs.get("source"))
+                for odim_key, global_attr in _ODIM_SOURCE_TO_GLOBAL_ATTRS.items():
+                    value = parsed.get(odim_key)
+                    if value is not None:
+                        attributes[global_attr] = value
 
         return FrozenDict(attributes)
 

--- a/xradar/model.py
+++ b/xradar/model.py
@@ -71,7 +71,7 @@ required_global_attrs = dict(
         ("Conventions", "Cf/Radial"),
         ("version", "Cf/Radial version number"),
         ("title", "short description of file contents"),
-        ("instrument_name", "nameThe  of radar or lidar"),
+        ("instrument_name", "name of radar or lidar"),
         ("institution", "where the original data were produced"),
         (
             "references",
@@ -81,6 +81,19 @@ required_global_attrs = dict(
         ("history", "list of modifications to the original data"),
         ("comment", "miscellaneous information"),
         ("platform_is_mobile", "'true' or 'false', assumed 'false' if missing"),
+        (
+            "wmo__id",
+            "the traditional WMO identifier for the observing station/platform",
+        ),
+        ("node", "node identifier of the radar site"),
+        (
+            "wmo__originating_centre",
+            "the originator of the data according to Common Code Table C–11",
+        ),
+        (
+            "wmo__wsi",
+            "the WIGOS station identifier (WSI) for the observing station/platform",
+        ),
     ]
 )
 


### PR DESCRIPTION
## Summary

This PR extends the ODIM backend to extract additional global attributes from the `/what/source` metadata field when importing ODIM files.

The extracted values are mapped onto the following FM301 global attributes in the xradar memory model:
- `wmo__id`
- `site_name`
- `node`
- `wmo__originating_centre`
- `wmo__wsi`

## Details

The ODIM `/what/source` string is parsed as key-value metadata and used to populate dataset global attributes during import.

This change also handles source strings containing non-ASCII station names encoded through surrogate-escaped UTF-8 byte sequences, so values such as for example `Sürgavere` are preserved correctly.

## Tests

Added coverage to verify:
- parsing of `/what/source` into global attributes
- correct recovery of UTF-8 text from surrogate-escaped source strings